### PR TITLE
Feat path script

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,7 @@ jobs:
         go-version:  1.21
     - name: build
       run: |
+        echo ${GITHUB_REF#refs/tags/}
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}
         fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,8 +20,6 @@ jobs:
         go-version:  1.21
     - name: build
       run: |
-        echo ${GITHUB_REF#refs/tags/}
-        echo $GITHUB_REF
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}
         fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: build
       run: |
         echo ${GITHUB_REF#refs/tags/}
-        echo GITHUB_REF
+        echo $GITHUB_REF
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}
         fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,7 @@ jobs:
     - name: build
       run: |
         echo ${GITHUB_REF#refs/tags/}
+        echo GITHUB_REF
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=${GITHUB_REF#refs/tags/}
         fi

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -349,6 +349,5 @@ func JobService(c *cluster.Cluster, name string, token string, endpoint string, 
 }
 
 func getScriptPath(scriptPath string, servicePath string) string {
-	wd, _ := os.Getwd()
-	return wd + "/" + filepath.Dir(servicePath) + "/" + scriptPath
+	return filepath.Dir(servicePath) + "/" + scriptPath
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -66,7 +67,7 @@ func ReadFDL(path string) (fdl *FDL, err error) {
 	for _, element := range fdl.Functions.Oscar {
 		for clusterID, svc := range element {
 			// Embed script
-			scriptPath := svc.Script
+			scriptPath := getScriptPath(svc.Script, path)
 			script, err := os.ReadFile(scriptPath)
 			if err != nil {
 				return fdl, fmt.Errorf("cannot load the script \"%s\" of service \"%s\", please check the path", scriptPath, svc.Name)
@@ -345,4 +346,9 @@ func JobService(c *cluster.Cluster, name string, token string, endpoint string, 
 	}
 
 	return res.Body, nil
+}
+
+func getScriptPath(scriptPath string, servicePath string) string {
+	wd, _ := os.Getwd()
+	return wd + "/" + filepath.Dir(servicePath) + "/" + scriptPath
 }


### PR DESCRIPTION
Solve https://github.com/grycap/issue-tracker/issues/77


oscar-cli loads the script file from a relative path of the fdl script. Not as from your console execution as before.