### PR TITLE
fix invocation

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -38,6 +38,7 @@ const infoPath = "/system/info"
 const configPath = "/system/config"
 const statusPath = "/system/status"
 const _DEFAULT_TIMEOUT = 20
+const BASIC_AUTH = "*cluster.basicAuthRoundTripper"
 
 var (
 	// ErrParsingEndpoint error message for cluster endpoint parsing
@@ -109,6 +110,17 @@ func (trt *tokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	// Add bearer token to requests
 	req.Header.Add("Authorization", "Bearer "+trt.token)
 	return trt.transport.RoundTrip(req)
+}
+
+func (cluster *Cluster) SetToken(client *http.Client, token string) {
+	var transport http.RoundTripper = &http.Transport{
+		// Enable/disable ssl verification
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cluster.SSLVerify},
+	}
+	client.Transport = &tokenRoundTripper{
+		token:     token,
+		transport: transport,
+	}
 }
 
 // GetClientSafe returns an HTTP client to communicate with the cluster without exiting on errors.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/goccy/go-yaml"
@@ -259,6 +260,13 @@ func RunService(c *cluster.Cluster, name string, token string, endpoint string, 
 	client := http.DefaultClient
 	if token == "" {
 		client, _ = c.GetClientSafe()
+		if reflect.TypeOf(client.Transport).String() == cluster.BASIC_AUTH {
+			svc, err := GetService(c, name)
+			if err != nil {
+				return nil, err
+			}
+			c.SetToken(client, svc.Token)
+		}
 	} else {
 		client = http.DefaultClient
 	}
@@ -274,6 +282,8 @@ func RunService(c *cluster.Cluster, name string, token string, endpoint string, 
 	}
 	runServiceURL.Path = path.Join(runServiceURL.Path, runPath, name)
 	// Make the request
+	fmt.Println("Invoking service at:", runServiceURL.String())
+	fmt.Println("Invoking service at:", client.Transport)
 	req, err := http.NewRequest(http.MethodPost, runServiceURL.String(), input)
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -300,6 +310,13 @@ func JobService(c *cluster.Cluster, name string, token string, endpoint string, 
 	client := http.DefaultClient
 	if token == "" {
 		client, _ = c.GetClientSafe()
+		if reflect.TypeOf(client.Transport).String() == "*cluster.basicAuthRoundTripper" {
+			svc, err := GetService(c, name)
+			if err != nil {
+				return nil, err
+			}
+			c.SetToken(client, svc.Token)
+		}
 	} else {
 		client = http.DefaultClient
 	}


### PR DESCRIPTION
#Fix https://github.com/grycap/issue-tracker/issues/228
#Fix https://github.com/grycap/issue-tracker/issues/198
#Fix https://github.com/grycap/issue-tracker/issues/119

**Authentication handling improvements:**

* Added a `SetToken` method to the `Cluster` type in `cluster.go`, allowing an HTTP client to be configured with a bearer token using a custom `tokenRoundTripper`.
* Updated `RunService` and `JobService` in `service.go` to check if the client's transport is a basic auth round tripper; if so, it retrieves the service token and sets it using the new `SetToken` method to ensure proper token-based authentication. [[1]](diffhunk://#diff-2b655ba613ca8386fd9f4c383200480492ee25711e24a575f3fc8b33531b4672R263-R269) [[2]](diffhunk://#diff-2b655ba613ca8386fd9f4c383200480492ee25711e24a575f3fc8b33531b4672R313-R319)

**Code clarity and debugging:**

* Introduced a `BASIC_AUTH` constant in `cluster.go` to identify the basic auth round tripper type.
* Added debugging output in `RunService` to print the service URL and client transport information when invoking a service.
* Imported the `reflect` package in `service.go` to enable runtime type checking of the HTTP client's transport.