### PR TITLE
Improved TUI stability and remove flickering

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -345,7 +345,8 @@ func (cluster *Cluster) getAccessToken() (string, error) {
 		return "", fmt.Errorf("error at new request: %v", err)
 	}
 	var res *http.Response
-	client := &http.Client{}
+	// Defensive timeout to avoid hanging the TUI when the IdP is slow/unreachable.
+	client := &http.Client{Timeout: 15 * time.Second}
 	res, err = client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error in the request : %v", err)

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -7,7 +7,9 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -120,150 +122,7 @@ func Run(ctx context.Context, conf *config.Config) error {
 	app.SetRoot(pages, true)
 	app.SetFocus(state.clusterList)
 	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		if state.searchVisible {
-			if event.Key() == tcell.KeyEsc {
-				state.hideSearch()
-				return nil
-			}
-			return event
-		}
-		if state.autoRefreshPromptVisible {
-			if event.Key() == tcell.KeyEsc {
-				state.hideAutoRefreshPrompt()
-				return nil
-			}
-			return event
-		}
-
-		switch event.Key() {
-		case tcell.KeyTab:
-			if app.GetFocus() == state.clusterList {
-				if state.modeIsServices() {
-					state.markServicePanelVisited()
-				}
-				app.SetFocus(state.serviceTable)
-			} else if state.modeIsBuckets() && app.GetFocus() == state.serviceTable {
-				state.focusBucketObjectsTable()
-			} else {
-				app.SetFocus(state.clusterList)
-			}
-			return nil
-		case tcell.KeyRight:
-			if app.GetFocus() == state.clusterList {
-				if state.modeIsServices() {
-					state.markServicePanelVisited()
-				}
-				app.SetFocus(state.serviceTable)
-				return nil
-			}
-			if state.modeIsBuckets() && app.GetFocus() == state.serviceTable {
-				state.focusBucketObjectsTable()
-				return nil
-			}
-		case tcell.KeyLeft:
-			if app.GetFocus() == state.serviceTable {
-				app.SetFocus(state.clusterList)
-				return nil
-			}
-			if app.GetFocus() == state.bucketObjectsTable {
-				app.SetFocus(state.serviceTable)
-				return nil
-			}
-		case tcell.KeyBacktab:
-			if app.GetFocus() == state.serviceTable {
-				app.SetFocus(state.clusterList)
-				return nil
-			}
-			if app.GetFocus() == state.bucketObjectsTable {
-				app.SetFocus(state.serviceTable)
-				return nil
-			}
-		case tcell.KeyBackspace, tcell.KeyBackspace2:
-			if app.GetFocus() == state.detailsView {
-				app.SetFocus(state.serviceTable)
-				return nil
-			}
-			if app.GetFocus() == state.serviceTable {
-				state.switchToServices(ctx)
-				return nil
-			}
-		case tcell.KeyEnter:
-			if app.GetFocus() == state.serviceTable {
-				state.switchToLogs(ctx)
-				return nil
-			}
-		}
-
-		switch event.Rune() {
-		case 'q', 'Q':
-			app.Stop()
-			return nil
-		case 'r':
-			state.refreshCurrent(ctx)
-			return nil
-		case 'w', 'W':
-			state.promptAutoRefresh()
-			return nil
-		case 'b', 'B':
-			state.switchToBuckets(ctx)
-			return nil
-		case 's', 'S':
-			state.switchToServices(ctx)
-			return nil
-		case 'o', 'O':
-			if state.modeIsBuckets() {
-				state.reloadBucketObjects(ctx)
-				state.focusBucketObjectsTable()
-				return nil
-			}
-		case 'n', 'N':
-			if state.modeIsBuckets() {
-				state.nextBucketObjectsPage(ctx)
-				return nil
-			}
-		case 'p', 'P':
-			if state.modeIsBuckets() {
-				state.previousBucketObjectsPage(ctx)
-				return nil
-			}
-		case 'a', 'A':
-			if state.modeIsBuckets() {
-				state.loadAllBucketObjects(ctx)
-				return nil
-			}
-		case 'd', 'D':
-			if app.GetFocus() == state.serviceTable && state.modeIsServices() {
-				state.requestDeletion()
-				return nil
-			}
-		case 'v', 'V':
-			state.queueUpdate(func() {
-				if state.app.GetFocus() != state.detailsView {
-					state.app.SetFocus(state.detailsView)
-				} else {
-					state.app.SetFocus(state.serviceTable)
-				}
-			})
-			return nil
-		case 'l', 'L':
-			if app.GetFocus() == state.serviceTable {
-				state.switchToLogs(ctx)
-				return nil
-			}
-		case '?':
-			state.toggleLegend()
-			return nil
-		case 'i', 'I':
-			state.showClusterInfo()
-			return nil
-		case 't', 'T':
-			state.showClusterStatus()
-			return nil
-		case '/':
-			state.initiateSearch(ctx)
-			return nil
-		}
-		return event
+		return state.safeInputCapture(ctx, event)
 	})
 
 	go func() {
@@ -476,6 +335,173 @@ func (s *uiState) handleSelection(row int, immediate bool) {
 		return
 	}
 	s.handleServiceSelection(row, immediate)
+}
+
+func (s *uiState) safeInputCapture(ctx context.Context, event *tcell.EventKey) *tcell.EventKey {
+	if event == nil {
+		return nil
+	}
+	// Filter out non-printable runes early to avoid edge cases in tview.
+	if event.Key() == tcell.KeyRune && !unicode.IsPrint(event.Rune()) {
+		return nil
+	}
+	if !atomic.CompareAndSwapInt32(&s.inputHandling, 0, 1) {
+		return nil
+	}
+	defer atomic.StoreInt32(&s.inputHandling, 0)
+	defer func() {
+		if r := recover(); r != nil {
+			// Ignore panics from input handling to keep the UI responsive.
+		}
+	}()
+	return s.handleInput(ctx, event)
+}
+
+func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell.EventKey {
+	if s.searchVisible {
+		if event.Key() == tcell.KeyEsc {
+			s.hideSearch()
+			return nil
+		}
+		return event
+	}
+	if s.autoRefreshPromptVisible {
+		if event.Key() == tcell.KeyEsc {
+			s.hideAutoRefreshPrompt()
+			return nil
+		}
+		return event
+	}
+
+	switch event.Key() {
+	case tcell.KeyTab:
+		if s.app.GetFocus() == s.clusterList {
+			if s.modeIsServices() {
+				s.markServicePanelVisited()
+			}
+			s.app.SetFocus(s.serviceTable)
+		} else if s.modeIsBuckets() && s.app.GetFocus() == s.serviceTable {
+			s.focusBucketObjectsTable()
+		} else {
+			s.app.SetFocus(s.clusterList)
+		}
+		return nil
+	case tcell.KeyRight:
+		if s.app.GetFocus() == s.clusterList {
+			if s.modeIsServices() {
+				s.markServicePanelVisited()
+			}
+			s.app.SetFocus(s.serviceTable)
+			return nil
+		}
+		if s.modeIsBuckets() && s.app.GetFocus() == s.serviceTable {
+			s.focusBucketObjectsTable()
+			return nil
+		}
+	case tcell.KeyLeft:
+		if s.app.GetFocus() == s.serviceTable {
+			s.app.SetFocus(s.clusterList)
+			return nil
+		}
+		if s.app.GetFocus() == s.bucketObjectsTable {
+			s.app.SetFocus(s.serviceTable)
+			return nil
+		}
+	case tcell.KeyBacktab:
+		if s.app.GetFocus() == s.serviceTable {
+			s.app.SetFocus(s.clusterList)
+			return nil
+		}
+		if s.app.GetFocus() == s.bucketObjectsTable {
+			s.app.SetFocus(s.serviceTable)
+			return nil
+		}
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if s.app.GetFocus() == s.detailsView {
+			s.app.SetFocus(s.serviceTable)
+			return nil
+		}
+		if s.app.GetFocus() == s.serviceTable {
+			s.switchToServices(ctx)
+			return nil
+		}
+	case tcell.KeyEnter:
+		if s.app.GetFocus() == s.serviceTable {
+			s.switchToLogs(ctx)
+			return nil
+		}
+	}
+
+	switch event.Rune() {
+	case 'q', 'Q':
+		s.app.Stop()
+		return nil
+	case 'r':
+		s.refreshCurrent(ctx)
+		return nil
+	case 'w', 'W':
+		s.promptAutoRefresh()
+		return nil
+	case 'b', 'B':
+		s.switchToBuckets(ctx)
+		return nil
+	case 's', 'S':
+		s.switchToServices(ctx)
+		return nil
+	case 'o', 'O':
+		if s.modeIsBuckets() {
+			s.reloadBucketObjects(ctx)
+			s.focusBucketObjectsTable()
+			return nil
+		}
+	case 'n', 'N':
+		if s.modeIsBuckets() {
+			s.nextBucketObjectsPage(ctx)
+			return nil
+		}
+	case 'p', 'P':
+		if s.modeIsBuckets() {
+			s.previousBucketObjectsPage(ctx)
+			return nil
+		}
+	case 'a', 'A':
+		if s.modeIsBuckets() {
+			s.loadAllBucketObjects(ctx)
+			return nil
+		}
+	case 'd', 'D':
+		if s.app.GetFocus() == s.serviceTable && s.modeIsServices() {
+			s.requestDeletion()
+			return nil
+		}
+	case 'v', 'V':
+		s.queueUpdate(func() {
+			if s.app.GetFocus() != s.detailsView {
+				s.app.SetFocus(s.detailsView)
+			} else {
+				s.app.SetFocus(s.serviceTable)
+			}
+		})
+		return nil
+	case 'l', 'L':
+		if s.app.GetFocus() == s.serviceTable {
+			s.switchToLogs(ctx)
+			return nil
+		}
+	case '?':
+		s.toggleLegend()
+		return nil
+	case 'i', 'I':
+		s.showClusterInfo()
+		return nil
+	case 't', 'T':
+		s.showClusterStatus()
+		return nil
+	case '/':
+		s.initiateSearch(ctx)
+		return nil
+	}
+	return event
 }
 
 func (s *uiState) queueUpdate(fn func()) {

--- a/pkg/tui/buckets_view.go
+++ b/pkg/tui/buckets_view.go
@@ -84,9 +84,14 @@ func (s *uiState) loadBuckets(ctx context.Context, name string, force bool) {
 	}
 
 	s.setStatus(fmt.Sprintf("[yellow]Loading buckets for cluster %s…", name))
-	s.queueUpdate(func() {
-		s.showBucketMessage("Loading buckets…")
-	})
+	s.mutex.Lock()
+	keepTable := force && s.currentCluster == name && len(s.bucketInfos) > 0
+	s.mutex.Unlock()
+	if !keepTable {
+		s.queueUpdate(func() {
+			s.showBucketMessage("Loading buckets…")
+		})
+	}
 
 	s.mutex.Lock()
 	if s.bucketCancel != nil {

--- a/pkg/tui/logs_view.go
+++ b/pkg/tui/logs_view.go
@@ -131,13 +131,17 @@ func (s *uiState) loadLogs(ctx context.Context, clusterName, serviceName string,
 	s.currentLogsKey = key
 	s.currentLogService = serviceName
 	s.currentLogCluster = clusterName
-	s.logEntries = nil
+	if !force {
+		s.logEntries = nil
+	}
 	s.mutex.Unlock()
 
 	s.setStatus(fmt.Sprintf("[yellow]Loading logs for %q…", serviceName))
-	s.queueUpdate(func() {
-		s.showLogMessage(serviceName, "Loading logs…")
-	})
+	if !(force && cachedKey == key && len(cachedEntries) > 0) {
+		s.queueUpdate(func() {
+			s.showLogMessage(serviceName, "Loading logs…")
+		})
+	}
 
 	page := ""
 	entries := map[string]*types.JobInfo{}

--- a/pkg/tui/logs_view.go
+++ b/pkg/tui/logs_view.go
@@ -98,6 +98,12 @@ func (s *uiState) loadLogs(ctx context.Context, clusterName, serviceName string,
 	if strings.TrimSpace(clusterName) == "" || strings.TrimSpace(serviceName) == "" {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Defensive timeout for long/looping pagination.
+	ctxFetch, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
 	clusterCfg := s.conf.Oscar[clusterName]
 	if clusterCfg == nil {
@@ -138,7 +144,7 @@ func (s *uiState) loadLogs(ctx context.Context, clusterName, serviceName string,
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-ctxFetch.Done():
 			s.setStatus("[red]Log loading cancelled")
 			return
 		default:

--- a/pkg/tui/services_view.go
+++ b/pkg/tui/services_view.go
@@ -136,9 +136,14 @@ func (s *uiState) loadServices(ctx context.Context, name string, force bool) {
 	}
 
 	s.setStatus(fmt.Sprintf("[yellow]Loading services for cluster %s…", name))
-	s.queueUpdate(func() {
-		s.showServiceMessage("Loading…")
-	})
+	s.mutex.Lock()
+	keepTable := force && s.currentCluster == name && len(s.currentServices) > 0
+	s.mutex.Unlock()
+	if !keepTable {
+		s.queueUpdate(func() {
+			s.showServiceMessage("Loading…")
+		})
+	}
 
 	s.mutex.Lock()
 	if s.refreshing && !force && s.loadingCluster == name {

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -122,6 +122,7 @@ type uiState struct {
 	currentLogJobKey         string
 	currentLogService        string
 	currentLogCluster        string
+	inputHandling            int32
 }
 
 type bucketObjectState struct {


### PR DESCRIPTION
This PR hardens the interactive TUI against input-related hangs, adds defensive timeouts for OIDC token refresh, and reduces UI flicker during auto‑refresh.

  1. Added a guarded input handler (safeInputCapture) that filters non-printable runes, prevents re-entrant input handling, and safely recovers from panics to keep the UI responsive.
  2. Added a 15s HTTP timeout when exchanging refresh tokens for access tokens.
  3. Reduced panel flicker by avoiding “Loading…” table replacement during forced refresh when data already exists (services, buckets, logs).