### PR TITLE
Add bucket deletion support in the OSCAR TUI by wiring the existing delete flow to Buckets view

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,25 @@ Flags:
 
 Global Flags:
       --config string   set the location of the config file (YAML or JSON)
+
+##### status
+
+Show the status reported by the OSCAR Manager API, including node metrics, deployment readiness and MinIO statistics.
+
+```
+Usage:
+  oscar-cli cluster status [flags]
+
+Aliases:
+  status, s
+
+Flags:
+  -c, --cluster string   set the cluster
+  -o, --output string    output format (yaml or json) (default "yaml")
+  -h, --help             help for status
+
+Global Flags:
+      --config string   set the location of the config file (YAML or JSON)
 ```
 
 ##### list
@@ -214,7 +233,7 @@ Flags:
       --owner string    GitHub owner that hosts the curated services (default "grycap")
       --path string     subdirectory inside the repository that contains the services
       --ref string      Git reference (branch, tag, or commit) to query (default "main")
-  -n, --name string     override the OSCAR service name during deployment
+  -n, --name string     override the OSCAR service and primary bucket names during deployment
       --repo string     GitHub repository that hosts the curated services (default "oscar-hub")
 
 Global Flags:

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -194,19 +194,19 @@ func overrideServiceName(svc *types.Service, newName string) {
 	if override == "" {
 		return
 	}
-	original := strings.TrimSpace(svc.Name)
-	if original == "" {
-		svc.Name = override
-		return
-	}
-	if original == override {
-		return
+	originalName := strings.TrimSpace(svc.Name)
+	primaryBucket := primaryBucketName(svc)
+	oldBucket := originalName
+	if primaryBucket != "" {
+		oldBucket = primaryBucket
 	}
 
-	renameStoragePaths(&svc.Input, original, override)
-	renameStoragePaths(&svc.Output, original, override)
-	if svc.Mount.Path != "" {
-		svc.Mount.Path = replacePathBucket(svc.Mount.Path, original, override)
+	if strings.TrimSpace(oldBucket) != "" && !strings.EqualFold(oldBucket, override) {
+		renameStoragePaths(&svc.Input, oldBucket, override)
+		renameStoragePaths(&svc.Output, oldBucket, override)
+		if svc.Mount.Path != "" {
+			svc.Mount.Path = replacePathBucket(svc.Mount.Path, oldBucket, override)
+		}
 	}
 
 	svc.Name = override
@@ -257,4 +257,37 @@ func replacePathBucket(path, oldName, newName string) string {
 		builder += "/"
 	}
 	return builder
+}
+
+func primaryBucketName(svc *types.Service) string {
+	if svc == nil {
+		return ""
+	}
+	for _, cfg := range svc.Output {
+		if bucket := bucketFromPath(cfg.Path); bucket != "" {
+			return bucket
+		}
+	}
+	for _, cfg := range svc.Input {
+		if bucket := bucketFromPath(cfg.Path); bucket != "" {
+			return bucket
+		}
+	}
+	if bucket := bucketFromPath(svc.Mount.Path); bucket != "" {
+		return bucket
+	}
+	return ""
+}
+
+func bucketFromPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	trimmed := strings.Trim(path, " ")
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.SplitN(trimmed, "/", 2)
+	return parts[0]
 }

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -36,6 +36,36 @@ func TestOverrideServiceNameUpdatesPaths(t *testing.T) {
 	}
 }
 
+func TestOverrideServiceNameUpdatesPathsWhenBucketDiffersFromServiceName(t *testing.T) {
+	svc := &types.Service{
+		Name: "demo",
+		Input: []types.StorageIOConfig{
+			{Path: "workflow/in"},
+			{Path: "other/in"},
+		},
+		Output: []types.StorageIOConfig{{Path: "workflow"}},
+		Mount:  types.StorageIOConfig{Path: "workflow/mount"},
+	}
+
+	overrideServiceName(svc, "demo-new")
+
+	if svc.Name != "demo-new" {
+		t.Fatalf("expected service name demo-new, got %s", svc.Name)
+	}
+	if got := svc.Input[0].Path; got != "demo-new/in" {
+		t.Fatalf("expected first input path demo-new/in, got %s", got)
+	}
+	if got := svc.Input[1].Path; got != "other/in" {
+		t.Fatalf("unexpected path rewrite: %s", got)
+	}
+	if got := svc.Output[0].Path; got != "demo-new" {
+		t.Fatalf("expected output path demo-new, got %s", got)
+	}
+	if got := svc.Mount.Path; got != "demo-new/mount" {
+		t.Fatalf("expected mount path demo-new/mount, got %s", got)
+	}
+}
+
 func TestReplacePathBucket(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/cmd/cluster.go
+++ b/cmd/cluster.go
@@ -42,6 +42,7 @@ func makeClusterCmd() *cobra.Command {
 	clusterCmd.AddCommand(makeClusterAddCmd())
 	clusterCmd.AddCommand(makeClusterRemoveCmd())
 	clusterCmd.AddCommand(makeClusterInfoCmd())
+	clusterCmd.AddCommand(makeClusterStatusCmd())
 	clusterCmd.AddCommand(makeClusterListCmd())
 	clusterCmd.AddCommand(makeClusterDefaultCmd())
 

--- a/cmd/cluster_status.go
+++ b/cmd/cluster_status.go
@@ -1,0 +1,82 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/grycap/oscar-cli/pkg/cluster"
+	"github.com/grycap/oscar-cli/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func clusterStatusFunc(cmd *cobra.Command, args []string) error {
+	conf, err := config.ReadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	clusterName, err := getCluster(cmd, conf)
+	if err != nil {
+		return err
+	}
+
+	status, err := conf.Oscar[clusterName].GetClusterStatus()
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	switch output {
+	case "json":
+		if err := clusterInfoPrintJSON(cmd, status); err != nil {
+			return err
+		}
+	default:
+		outputyaml, err := yaml.Marshal(status)
+		if err != nil {
+			return fmt.Errorf("failed to serialize cluster status: %w", err)
+		}
+		fmt.Print(string(outputyaml))
+
+	}
+
+	return nil
+}
+
+func clusterInfoPrintJSON(cmd *cobra.Command, objects cluster.StatusInfo) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(objects)
+}
+
+func makeClusterStatusCmd() *cobra.Command {
+	clusterStatusCmd := &cobra.Command{
+		Use:     "status",
+		Short:   "Show status information of an OSCAR cluster",
+		Args:    cobra.NoArgs,
+		Aliases: []string{"s"},
+		RunE:    clusterStatusFunc,
+	}
+
+	clusterStatusCmd.Flags().StringP("cluster", "c", "", "set the cluster")
+	clusterStatusCmd.Flags().StringP("output", "o", "table", "output format (json)")
+
+	return clusterStatusCmd
+}

--- a/cmd/cluster_status_test.go
+++ b/cmd/cluster_status_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grycap/oscar-cli/pkg/cluster"
+)
+
+func TestClusterStatusCommandPrintsStatus(t *testing.T) {
+	expected := cluster.StatusInfo{
+		Cluster: cluster.ClusterStatus{
+			NodesCount: 1,
+			Metrics: cluster.ClusterMetrics{
+				CPU: cluster.CPUMetrics{
+					TotalFreeCores:     2,
+					MaxFreeOnNodeCores: 2,
+				},
+			},
+		},
+		Oscar: cluster.OscarStatus{
+			DeploymentName: "oscar-manager",
+			Deployment: cluster.OscarDeployment{
+				CreationTimestamp: time.Unix(1700000000, 0).UTC(),
+			},
+		},
+		MinIO: cluster.MinioStatus{
+			BucketsCount: 4,
+			TotalObjects: 10,
+		},
+	}
+
+	const (
+		username = "user"
+		password = "pass"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/system/status" {
+			http.NotFound(w, r)
+			return
+		}
+		gotUser, gotPass, ok := r.BasicAuth()
+		if !ok || gotUser != username || gotPass != password {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(expected); err != nil {
+			t.Fatalf("encoding status: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	configFile := writeConfigFile(t, "alpha", server.URL)
+
+	stdout, stderr, err := runCommand(t,
+		"cluster", "--config", configFile,
+		"status",
+		"--cluster", "alpha",
+	)
+	if err != nil {
+		t.Fatalf("cluster status command returned error: %v", err)
+	}
+	if stderr != "" {
+		t.Fatalf("expected empty stderr, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "nodes_count: 1") {
+		t.Fatalf("expected nodes_count in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "deployment_name: oscar-manager") {
+		t.Fatalf("expected deployment_name in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, "buckets_count: 4") {
+		t.Fatalf("expected buckets_count in output, got %q", stdout)
+	}
+}
+
+func TestClusterStatusCommandError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	configFile := writeConfigFile(t, "alpha", server.URL)
+
+	_, _, err := runCommand(t,
+		"cluster", "--config", configFile,
+		"status",
+		"--cluster", "alpha",
+	)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err.Error() != "boom\n" {
+		t.Fatalf("expected boom error, got %v", err)
+	}
+}

--- a/cmd/hub_deploy.go
+++ b/cmd/hub_deploy.go
@@ -82,7 +82,7 @@ func hubDeployFunc(cmd *cobra.Command, args []string, opts *hubDeployOptions) er
 	}
 
 	if opts.name != "" {
-		serviceDef.Name = opts.name
+		overrideServiceName(serviceDef, opts.name)
 	}
 
 	action := "Creating"
@@ -128,7 +128,7 @@ func makeHubDeployCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.rootPath, "path", opts.rootPath, "subdirectory inside the repository that contains the services")
 	cmd.Flags().StringVar(&opts.ref, "ref", opts.ref, "Git reference (branch, tag, or commit) to query")
 	cmd.Flags().StringVar(&opts.apiBase, "api-base", "", "override the GitHub API base URL")
-	cmd.Flags().StringVarP(&opts.name, "name", "n", "", "override the OSCAR service name during deployment")
+	cmd.Flags().StringVarP(&opts.name, "name", "n", "", "override the OSCAR service and primary bucket names during deployment")
 	cmd.Flags().StringVar(&opts.localPath, "local-path", "", "use a local directory containing the RO-Crate metadata instead of fetching it from GitHub")
 	cmd.Flags().StringP("cluster", "c", "", "set the cluster")
 

--- a/cmd/hub_deploy_test.go
+++ b/cmd/hub_deploy_test.go
@@ -25,6 +25,15 @@ functions:
         name: Cowsay
         image: ghcr.io/demo/cowsay:latest
         script: script.sh
+        input:
+        - storage_provider: minio.default
+          path: cowsay/in
+        output:
+        - storage_provider: minio.default
+          path: cowsay
+        mount:
+          storage_provider: minio.default
+          path: cowsay/mount
 `
 		scriptContent = "#!/bin/bash\necho moo\n"
 	)
@@ -97,6 +106,21 @@ default: test
 
 	if applied.Name != override {
 		t.Fatalf("expected service name %s, got %s", override, applied.Name)
+	}
+	if len(applied.Input) != 1 {
+		t.Fatalf("expected 1 input entry, got %d", len(applied.Input))
+	}
+	if got := applied.Input[0].Path; got != "alt-cowsay/in" {
+		t.Fatalf("expected input path alt-cowsay/in, got %s", got)
+	}
+	if len(applied.Output) != 1 {
+		t.Fatalf("expected 1 output entry, got %d", len(applied.Output))
+	}
+	if got := applied.Output[0].Path; got != "alt-cowsay" {
+		t.Fatalf("expected output path alt-cowsay, got %s", got)
+	}
+	if got := applied.Mount.Path; got != "alt-cowsay/mount" {
+		t.Fatalf("expected mount path alt-cowsay/mount, got %s", got)
 	}
 	if applied.Script != scriptContent {
 		t.Fatalf("expected script content %q, got %q", scriptContent, applied.Script)

--- a/go.mod
+++ b/go.mod
@@ -22,10 +22,11 @@ require (
 require (
 	github.com/gdamore/tcell/v2 v2.8.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
-	github.com/grycap/oscar/v3 v3.3.0
+	github.com/grycap/oscar/v3 v3.6.5
 	github.com/indigo-dc/liboidcagent-go v0.3.0
 	github.com/rivo/tview v0.42.0
 	golang.org/x/term v0.28.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -58,14 +59,13 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
-	golang.org/x/oauth2 v0.10.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apimachinery v0.29.2 // indirect
 	k8s.io/client-go v0.29.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/grycap/cdmi-client-go v0.1.1 h1:kHIrrLhvaCD0VyzEa5HOg7d/VgRE11yh9Ztdy
 github.com/grycap/cdmi-client-go v0.1.1/go.mod h1:ZqWeQS3YBJVXxg3HOIkAu1MLNJ4+7s848CyIPMFT5Gc=
 github.com/grycap/oscar/v3 v3.3.0 h1:+zDkUu6IryJ7Xq2QGNDkDCvhMrVhpjAU4cmiW2or+wc=
 github.com/grycap/oscar/v3 v3.3.0/go.mod h1:EN8kr1DLZc99llMJvXk4vnfVKQzEMLrnWdqaEKdg8YI=
+github.com/grycap/oscar/v3 v3.6.5 h1:iQDKY7Vqv/iWGLzyFoxONYQsHA8WunDhyOXP2JKGUis=
+github.com/grycap/oscar/v3 v3.6.5/go.mod h1:Js7D2jFlI5oCYw0QBFp1i3miRYtFLHF6HEALDbSoAis=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -197,6 +199,8 @@ golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
 golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -36,7 +36,9 @@ import (
 
 const infoPath = "/system/info"
 const configPath = "/system/config"
+const statusPath = "/system/status"
 const _DEFAULT_TIMEOUT = 20
+const BASIC_AUTH = "*cluster.basicAuthRoundTripper"
 
 var (
 	// ErrParsingEndpoint error message for cluster endpoint parsing
@@ -108,6 +110,17 @@ func (trt *tokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	// Add bearer token to requests
 	req.Header.Add("Authorization", "Bearer "+trt.token)
 	return trt.transport.RoundTrip(req)
+}
+
+func (cluster *Cluster) SetToken(client *http.Client, token string) {
+	var transport http.RoundTripper = &http.Transport{
+		// Enable/disable ssl verification
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cluster.SSLVerify},
+	}
+	client.Transport = &tokenRoundTripper{
+		token:     token,
+		transport: transport,
+	}
 }
 
 // GetClientSafe returns an HTTP client to communicate with the cluster without exiting on errors.
@@ -240,6 +253,41 @@ func (cluster *Cluster) GetClusterConfig() (cfg types.Config, err error) {
 	json.NewDecoder(res.Body).Decode(&cfg)
 
 	return cfg, nil
+}
+
+// GetClusterStatus returns the status of an OSCAR cluster
+func (cluster *Cluster) GetClusterStatus() (status StatusInfo, err error) {
+	getStatusURL, err := url.Parse(cluster.Endpoint)
+	if err != nil {
+		return status, ErrParsingEndpoint
+	}
+	getStatusURL.Path = path.Join(getStatusURL.Path, statusPath)
+
+	req, err := http.NewRequest(http.MethodGet, getStatusURL.String(), nil)
+	if err != nil {
+		return status, ErrMakingRequest
+	}
+
+	client, err := cluster.GetClientSafe()
+	if err != nil {
+		return status, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return status, ErrSendingRequest
+	}
+	defer res.Body.Close()
+
+	if err := CheckStatusCode(res); err != nil {
+		return status, err
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&status); err != nil {
+		return status, fmt.Errorf("unable to parse cluster status response: %w", err)
+	}
+
+	return status, nil
 }
 
 // CheckStatusCode checks if a cluster response is valid and returns an appropriate error if not

--- a/pkg/cluster/status_types.go
+++ b/pkg/cluster/status_types.go
@@ -1,0 +1,92 @@
+package cluster
+
+import "time"
+
+// StatusInfo aggregates the information returned by /system/status.
+type StatusInfo struct {
+	Cluster ClusterStatus `json:"cluster"`
+	Oscar   OscarStatus   `json:"oscar"`
+	MinIO   MinioStatus   `json:"minio"`
+}
+
+type ClusterStatus struct {
+	NodesCount int64          `json:"nodes_count"`
+	Metrics    ClusterMetrics `json:"metrics"`
+	Nodes      []NodeDetail   `json:"nodes"`
+}
+
+type ClusterMetrics struct {
+	CPU    CPUMetrics    `json:"cpu"`
+	Memory MemoryMetrics `json:"memory"`
+	GPU    GPUMetrics    `json:"gpu"`
+}
+
+type CPUMetrics struct {
+	TotalFreeCores     int64 `json:"total_free_cores"`
+	MaxFreeOnNodeCores int64 `json:"max_free_on_node_cores"`
+}
+
+type MemoryMetrics struct {
+	TotalFreeBytes     int64 `json:"total_free_bytes"`
+	MaxFreeOnNodeBytes int64 `json:"max_free_on_node_bytes"`
+}
+
+type GPUMetrics struct {
+	TotalGPU int64 `json:"total_gpu"`
+}
+
+type NodeDetail struct {
+	Name        string                `json:"name"`
+	CPU         NodeResource          `json:"cpu"`
+	Memory      NodeResource          `json:"memory"`
+	GPU         int64                 `json:"gpu"`
+	IsInterlink bool                  `json:"is_interlink"`
+	Status      string                `json:"status"`
+	Conditions  []NodeConditionSimple `json:"conditions"`
+}
+
+type NodeResource struct {
+	CapacityCores int64 `json:"capacity_cores,omitempty"`
+	UsageCores    int64 `json:"usage_cores,omitempty"`
+	CapacityBytes int64 `json:"capacity_bytes,omitempty"`
+	UsageBytes    int64 `json:"usage_bytes,omitempty"`
+}
+
+type NodeConditionSimple struct {
+	Type   string `json:"type"`
+	Status bool   `json:"status"`
+}
+
+type OscarStatus struct {
+	DeploymentName string          `json:"deployment_name"`
+	Ready          bool            `json:"ready"`
+	Deployment     OscarDeployment `json:"deployment"`
+	JobsCount      int             `json:"jobs_count"`
+	Pods           PodStates       `json:"pods"`
+	OIDC           OIDCInfo        `json:"oidc"`
+}
+
+type OscarDeployment struct {
+	AvailableReplicas int32             `json:"available_replicas"`
+	ReadyReplicas     int32             `json:"ready_replicas"`
+	Replicas          int32             `json:"replicas"`
+	CreationTimestamp time.Time         `json:"creation_timestamp"`
+	Strategy          string            `json:"strategy"`
+	Labels            map[string]string `json:"labels"`
+}
+
+type PodStates struct {
+	Total  int            `json:"total"`
+	States map[string]int `json:"states"`
+}
+
+type OIDCInfo struct {
+	Enabled bool     `json:"enabled"`
+	Issuers []string `json:"issuers"`
+	Groups  []string `json:"groups"`
+}
+
+type MinioStatus struct {
+	BucketsCount int `json:"buckets_count"`
+	TotalObjects int `json:"total_objects"`
+}

--- a/pkg/service/logs.go
+++ b/pkg/service/logs.go
@@ -33,16 +33,10 @@ import (
 
 const logsPath = "/system/logs"
 
-type JobsResponse struct {
-	Jobs         map[string]*types.JobInfo `json:"jobs"`
-	NextPage     string                    `json:"next_page,omitempty"`
-	RemainingJob *int64                    `json:"remaining_jobs,omitempty"`
-}
-
 var ErrNoLogsFound = errors.New("service has no logs")
 
 // ListLogs returns a map with all the available logs from the given service
-func ListLogs(c *cluster.Cluster, name string, page string) (logMap JobsResponse, err error) {
+func ListLogs(c *cluster.Cluster, name string, page string) (logMap types.JobsResponse, err error) {
 	listLogsURL, err := url.Parse(c.Endpoint)
 	if err != nil {
 		return logMap, cluster.ErrParsingEndpoint
@@ -76,7 +70,7 @@ func ListLogs(c *cluster.Cluster, name string, page string) (logMap JobsResponse
 		return logMap, err
 	}
 	jobs := map[string]*types.JobInfo{}
-	jobsResponse := JobsResponse{}
+	jobsResponse := types.JobsResponse{}
 	// Try to decode the response body into the jobsResponse
 	err = json.NewDecoder(bytes.NewReader(body)).Decode(&jobsResponse)
 	if err != nil {
@@ -91,7 +85,7 @@ func ListLogs(c *cluster.Cluster, name string, page string) (logMap JobsResponse
 		if _, ok := jobs["jobs"]; ok {
 			return jobsResponse, err
 		} else {
-			jobsResponse = JobsResponse{Jobs: jobs, NextPage: "", RemainingJob: nil}
+			jobsResponse = types.JobsResponse{Jobs: jobs, NextPage: "", RemainingJob: nil}
 			return jobsResponse, err
 		}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/goccy/go-yaml"
@@ -259,6 +260,13 @@ func RunService(c *cluster.Cluster, name string, token string, endpoint string, 
 	client := http.DefaultClient
 	if token == "" {
 		client, _ = c.GetClientSafe()
+		if reflect.TypeOf(client.Transport).String() == cluster.BASIC_AUTH {
+			svc, err := GetService(c, name)
+			if err != nil {
+				return nil, err
+			}
+			c.SetToken(client, svc.Token)
+		}
 	} else {
 		client = http.DefaultClient
 	}
@@ -274,6 +282,8 @@ func RunService(c *cluster.Cluster, name string, token string, endpoint string, 
 	}
 	runServiceURL.Path = path.Join(runServiceURL.Path, runPath, name)
 	// Make the request
+	fmt.Println("Invoking service at:", runServiceURL.String())
+	fmt.Println("Invoking service at:", client.Transport)
 	req, err := http.NewRequest(http.MethodPost, runServiceURL.String(), input)
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
@@ -300,6 +310,13 @@ func JobService(c *cluster.Cluster, name string, token string, endpoint string, 
 	client := http.DefaultClient
 	if token == "" {
 		client, _ = c.GetClientSafe()
+		if reflect.TypeOf(client.Transport).String() == "*cluster.basicAuthRoundTripper" {
+			svc, err := GetService(c, name)
+			if err != nil {
+				return nil, err
+			}
+			c.SetToken(client, svc.Token)
+		}
 	} else {
 		client = http.DefaultClient
 	}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -14,52 +14,6 @@ import (
 
 	"github.com/grycap/oscar-cli/pkg/cluster"
 	"github.com/grycap/oscar-cli/pkg/config"
-	"github.com/grycap/oscar-cli/pkg/service"
-	"github.com/grycap/oscar-cli/pkg/storage"
-	"github.com/grycap/oscar/v3/pkg/types"
-)
-
-const legendText = `[yellow]Navigation[-]
-  ↑/↓  Move selection
-  ←/→ or Tab  Switch pane
-
-[yellow]Actions[-]
-  r  Refresh current view
-  d  Delete selected item
-  i  Show cluster info
-  l  Show service logs
-  w  Configure auto refresh
-  b  Switch to buckets view
-  s  Switch to services view
-  Enter  Focus bucket objects (bucket view)
-  o  Reload bucket objects (bucket view)
-  n/p  Next/previous bucket objects page
-  a  Load all bucket objects
-  q  Quit
-  ?  Toggle this help`
-
-type panelMode int
-
-const (
-	modeServices panelMode = iota
-	modeBuckets
-)
-
-var (
-	serviceHeaders      = []string{"Name", "Image", "CPU", "Memory"}
-	bucketHeaders       = []string{"Name", "Visibility", "Owner"}
-	bucketObjectHeaders = []string{"Name", "Size (B)", "Last Modified"}
-)
-
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d[::-] Delete selection · [::b]i[::-] Cluster info · [::b]l[::-] Service logs · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
-
-type searchTarget int
-
-const (
-	searchTargetNone searchTarget = iota
-	searchTargetClusters
-	searchTargetServices
-	searchTargetBuckets
 )
 
 // Run launches the interactive terminal user interface.
@@ -87,10 +41,13 @@ func Run(ctx context.Context, conf *config.Config) error {
 		failedClusters:     make(map[string]string),
 		mode:               modeServices,
 		bucketObjects:      make(map[string]*bucketObjectState),
+		serviceDefinitions: make(map[string]string),
+		logDetails:         make(map[string]string),
 	}
 
 	state.statusView.SetBorder(false)
 	state.detailsView.SetBorder(true)
+	state.detailsView.SetScrollable(true)
 	state.detailsView.SetTitle("Details")
 	state.detailsView.SetText("Select a cluster to view details")
 	state.bucketObjectsTable.SetBorder(true)
@@ -221,6 +178,20 @@ func Run(ctx context.Context, conf *config.Config) error {
 				app.SetFocus(state.serviceTable)
 				return nil
 			}
+		case tcell.KeyBackspace, tcell.KeyBackspace2:
+			if app.GetFocus() == state.detailsView {
+				app.SetFocus(state.serviceTable)
+				return nil
+			}
+			if app.GetFocus() == state.serviceTable {
+				state.switchToServices(ctx)
+				return nil
+			}
+		case tcell.KeyEnter:
+			if app.GetFocus() == state.serviceTable {
+				state.switchToLogs(ctx)
+				return nil
+			}
 		}
 
 		switch event.Rune() {
@@ -261,13 +232,22 @@ func Run(ctx context.Context, conf *config.Config) error {
 				return nil
 			}
 		case 'd', 'D':
-			if app.GetFocus() == state.serviceTable {
+			if app.GetFocus() == state.serviceTable && state.modeIsServices() {
 				state.requestDeletion()
 				return nil
 			}
+		case 'v', 'V':
+			state.queueUpdate(func() {
+				if state.app.GetFocus() != state.detailsView {
+					state.app.SetFocus(state.detailsView)
+				} else {
+					state.app.SetFocus(state.serviceTable)
+				}
+			})
+			return nil
 		case 'l', 'L':
 			if app.GetFocus() == state.serviceTable {
-				state.showServiceLogs()
+				state.switchToLogs(ctx)
 				return nil
 			}
 		case '?':
@@ -275,6 +255,9 @@ func Run(ctx context.Context, conf *config.Config) error {
 			return nil
 		case 'i', 'I':
 			state.showClusterInfo()
+			return nil
+		case 't', 'T':
+			state.showClusterStatus()
 			return nil
 		case '/':
 			state.initiateSearch(ctx)
@@ -315,75 +298,6 @@ func Run(ctx context.Context, conf *config.Config) error {
 	return nil
 }
 
-type uiState struct {
-	app                *tview.Application
-	conf               *config.Config
-	rootCtx            context.Context
-	statusView         *tview.TextView
-	detailsView        *tview.TextView
-	detailContainer    *tview.Flex
-	serviceTable       *tview.Table
-	bucketObjectsTable *tview.Table
-	clusterList        *tview.List
-	statusContainer    *tview.Flex
-	pages              *tview.Pages
-	mutex              *sync.Mutex
-
-	clusterNames             []string
-	currentCluster           string
-	currentServices          []*types.Service
-	refreshing               bool
-	started                  bool
-	pendingCluster           string
-	loadingCluster           string
-	failedClusters           map[string]string
-	loadCancel               context.CancelFunc
-	loadSeq                  int
-	detailTimer              *time.Timer
-	lastSelection            string
-	legendVisible            bool
-	confirmVisible           bool
-	savedFocus               tview.Primitive
-	mode                     panelMode
-	bucketInfos              []*storage.BucketInfo
-	bucketCancel             context.CancelFunc
-	bucketSeq                int
-	bucketCluster            string
-	bucketObjectsVisible     bool
-	bucketObjects            map[string]*bucketObjectState
-	currentBucketObjectsKey  string
-	bucketObjectsCancel      context.CancelFunc
-	bucketObjectsSeq         int
-	searchVisible            bool
-	searchInput              *tview.InputField
-	searchTarget             searchTarget
-	originalFocus            tview.Primitive
-	autoRefreshCancel        context.CancelFunc
-	autoRefreshTicker        *time.Ticker
-	autoRefreshPeriod        time.Duration
-	autoRefreshActive        bool
-	autoRefreshPromptVisible bool
-	autoRefreshInput         *tview.InputField
-	autoRefreshFocus         tview.Primitive
-	servicePanelVisited      bool
-}
-
-type bucketObjectState struct {
-	Objects       []*storage.BucketObject
-	NextPage      string
-	PrevTokens    []string
-	CurrentToken  string
-	IsTruncated   bool
-	Auto          bool
-	ReturnedItems int
-}
-
-type bucketObjectRequest struct {
-	Token      string
-	PrevTokens []string
-	Auto       bool
-}
-
 func (s *uiState) selectCluster(ctx context.Context, name string) {
 	s.mutex.Lock()
 	if name == s.currentCluster && s.refreshing && s.loadingCluster == name {
@@ -410,6 +324,14 @@ func (s *uiState) selectCluster(ctx context.Context, name string) {
 	}
 	s.lastSelection = ""
 	s.currentBucketObjectsKey = ""
+	s.logEntries = nil
+	s.currentLogsKey = ""
+	s.currentLogJobKey = ""
+	s.currentLogService = ""
+	s.currentLogCluster = ""
+	if s.mode == modeLogs {
+		s.mode = modeServices
+	}
 	s.currentCluster = name
 	mode := s.mode
 	errMsg, blocked := s.failedClusters[name]
@@ -462,6 +384,8 @@ func (s *uiState) refreshCurrent(ctx context.Context) {
 	}
 	if mode == modeBuckets {
 		go s.loadBuckets(ctx, name, true)
+	} else if mode == modeLogs {
+		go s.loadLogs(ctx, name, s.currentLogService, true)
 	} else {
 		go s.loadServices(ctx, name, true)
 	}
@@ -483,29 +407,6 @@ func (s *uiState) showClusterDetails(name string) {
 	})
 }
 
-func (s *uiState) markServicePanelVisited() {
-	s.mutex.Lock()
-	already := s.servicePanelVisited
-	s.servicePanelVisited = true
-	row, _ := s.serviceTable.GetSelection()
-	s.mutex.Unlock()
-	if already {
-		return
-	}
-	if row > 0 {
-		s.handleSelection(row, true)
-		return
-	}
-	s.setServiceDetailsText("Select a service to inspect details")
-}
-
-func (s *uiState) serviceDetailsEnabled() bool {
-	s.mutex.Lock()
-	visited := s.servicePanelVisited
-	s.mutex.Unlock()
-	return visited
-}
-
 func (s *uiState) modeIsServices() bool {
 	s.mutex.Lock()
 	mode := s.mode
@@ -520,301 +421,17 @@ func (s *uiState) modeIsBuckets() bool {
 	return mode == modeBuckets
 }
 
-func (s *uiState) setServiceDetailsText(text string) {
-	if !s.serviceDetailsEnabled() {
-		return
-	}
-	s.queueUpdate(func() {
-		s.detailsView.SetText(text)
-	})
-}
-
-func (s *uiState) switchToBuckets(ctx context.Context) {
-	if s.searchVisible {
-		s.hideSearch()
-	}
+func (s *uiState) modeIsLogs() bool {
 	s.mutex.Lock()
-	if s.confirmVisible || s.legendVisible {
-		s.mutex.Unlock()
-		return
-	}
-	if s.mode == modeBuckets {
-		s.mutex.Unlock()
-		return
-	}
-	s.mode = modeBuckets
-	if s.loadCancel != nil {
-		s.loadCancel()
-		s.loadCancel = nil
-		s.refreshing = false
-		s.loadingCluster = ""
-	}
-	if s.detailTimer != nil {
-		s.detailTimer.Stop()
-		s.detailTimer = nil
-	}
-	s.lastSelection = ""
-	s.currentBucketObjectsKey = ""
-	s.mutex.Unlock()
-
-	clusterName := s.currentCluster
-	if clusterName == "" {
-		s.setStatus("[red]Select a cluster to view buckets")
-		s.queueUpdate(func() {
-			s.showBucketMessage("Select a cluster to view buckets")
-		})
-		s.showBucketObjectsPrompt("Select a bucket to list objects")
-		s.showClusterDetails(clusterName)
-		return
-	}
-
-	s.showClusterDetails(clusterName)
-	s.queueUpdate(func() {
-		s.showBucketMessage("Loading buckets…")
-	})
-	s.showBucketObjectsPrompt("Select a bucket to list objects")
-
-	s.mutex.Lock()
-	cached := s.bucketInfos
-	cachedCluster := s.bucketCluster
-	s.mutex.Unlock()
-	if len(cached) > 0 && cachedCluster == clusterName {
-		s.renderBucketTable(cached)
-		s.setStatus(fmt.Sprintf("[green]Loaded %d bucket(s) for %s", len(cached), clusterName))
-		return
-	}
-
-	go s.loadBuckets(ctx, clusterName, false)
-}
-
-func (s *uiState) switchToServices(ctx context.Context) {
-	if s.searchVisible {
-		s.hideSearch()
-	}
-	s.mutex.Lock()
-	if s.confirmVisible || s.legendVisible {
-		s.mutex.Unlock()
-		return
-	}
-	if s.mode == modeServices {
-		s.mutex.Unlock()
-		return
-	}
-	s.mode = modeServices
-	if s.bucketCancel != nil {
-		s.bucketCancel()
-		s.bucketCancel = nil
-	}
-	if s.bucketObjectsCancel != nil {
-		s.bucketObjectsCancel()
-		s.bucketObjectsCancel = nil
-	}
-	if s.detailTimer != nil {
-		s.detailTimer.Stop()
-		s.detailTimer = nil
-	}
-	s.lastSelection = ""
-	s.currentBucketObjectsKey = ""
-	services := s.currentServices
-	clusterName := s.currentCluster
-	s.mutex.Unlock()
-
-	s.hideBucketObjectsPane()
-	s.showClusterDetails(clusterName)
-
-	if len(services) > 0 {
-		s.renderServiceTable(services)
-		s.setStatus(fmt.Sprintf("[green]Loaded %d service(s) for %s", len(services), clusterName))
-		return
-	}
-
-	if clusterName == "" {
-		s.queueUpdate(func() {
-			s.showServiceMessage("Select a cluster to view services")
-		})
-		return
-	}
-
-	s.queueUpdate(func() {
-		s.showServiceMessage("Loading…")
-	})
-	go s.loadServices(ctx, clusterName, true)
-}
-
-func (s *uiState) loadServices(ctx context.Context, name string, force bool) {
-	if name == "" {
-		return
-	}
-
-	defer func() {
-		if r := recover(); r != nil {
-			s.mutex.Lock()
-			s.refreshing = false
-			s.loadingCluster = ""
-			s.mutex.Unlock()
-			s.setStatus(fmt.Sprintf("[red]Unexpected error while loading services for %s: %v", name, r))
-		}
-	}()
-
-	cfg, ok := s.conf.Oscar[name]
-	if !ok || cfg == nil {
-		s.setStatus(fmt.Sprintf("[red]Cluster %q not found in configuration", name))
-		s.mutex.Lock()
-		s.refreshing = false
-		s.loadingCluster = ""
-		s.currentServices = nil
-		s.failedClusters[name] = fmt.Sprintf("Cluster %q not found in configuration", name)
-		s.mutex.Unlock()
-		s.queueUpdate(func() {
-			s.showServiceMessage("Cluster not found")
-		})
-		return
-	}
-
-	s.setStatus(fmt.Sprintf("[yellow]Loading services for cluster %s…", name))
-	s.queueUpdate(func() {
-		s.showServiceMessage("Loading…")
-	})
-
-	s.mutex.Lock()
-	if s.refreshing && !force && s.loadingCluster == name {
-		s.mutex.Unlock()
-		return
-	}
-	if s.loadCancel != nil {
-		s.loadCancel()
-		s.loadCancel = nil
-	}
-	if s.detailTimer != nil {
-		s.detailTimer.Stop()
-		s.detailTimer = nil
-	}
-	s.lastSelection = ""
-	s.loadSeq++
-	loadVersion := s.loadSeq
-	ctxFetch, cancel := context.WithTimeout(ctx, 15*time.Second)
-	s.refreshing = true
-	s.loadingCluster = name
-	s.loadCancel = cancel
-	s.mutex.Unlock()
-
-	servicesList, err := service.ListServicesWithContext(ctxFetch, cfg)
-	if err != nil {
-		message := fmt.Sprintf("Unable to load services for %s: %v", name, err)
-		s.setStatus(fmt.Sprintf("[red]%s", message))
-		s.mutex.Lock()
-		if loadVersion == s.loadSeq {
-			s.failedClusters[name] = message
-			s.refreshing = false
-			s.loadingCluster = ""
-			s.currentServices = nil
-			s.loadCancel = nil
-		}
-		s.mutex.Unlock()
-		s.queueUpdate(func() {
-			s.showServiceMessage("Unable to load services")
-		})
-		cancel()
-		return
-	}
-	if ctx.Err() != nil {
-		s.mutex.Lock()
-		if loadVersion == s.loadSeq {
-			s.refreshing = false
-			s.loadingCluster = ""
-			s.currentServices = nil
-			s.loadCancel = nil
-		}
-		s.mutex.Unlock()
-		cancel()
-		return
-	}
-
-	cancel()
-	s.mutex.Lock()
-	if loadVersion != s.loadSeq {
-		s.mutex.Unlock()
-		return
-	}
-	if s.currentCluster == name {
-		s.currentServices = servicesList
-		delete(s.failedClusters, name)
-	}
-	s.refreshing = false
-	s.loadingCluster = ""
-	s.loadCancel = nil
-	currentMode := s.mode
-	s.mutex.Unlock()
-
-	if currentMode == modeServices && s.currentCluster == name {
-		s.renderServiceTable(servicesList)
-		s.setStatus(fmt.Sprintf("[green]Loaded %d service(s) for %s", len(servicesList), name))
-	}
-}
-
-func (s *uiState) loadBuckets(ctx context.Context, name string, force bool) {
-	if name == "" {
-		return
-	}
-
-	clusterCfg := s.conf.Oscar[name]
-	if clusterCfg == nil {
-		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", name))
-		s.queueUpdate(func() {
-			s.showBucketMessage("Cluster not found")
-		})
-		return
-	}
-
-	s.setStatus(fmt.Sprintf("[yellow]Loading buckets for cluster %s…", name))
-	s.queueUpdate(func() {
-		s.showBucketMessage("Loading buckets…")
-	})
-
-	s.mutex.Lock()
-	if s.bucketCancel != nil {
-		s.bucketCancel()
-		s.bucketCancel = nil
-	}
-	s.bucketSeq++
-	seq := s.bucketSeq
-	ctxFetch, cancel := context.WithTimeout(ctx, 15*time.Second)
-	s.bucketCancel = cancel
-	s.mutex.Unlock()
-
-	buckets, err := storage.ListBucketsWithContext(ctxFetch, clusterCfg)
-	cancel()
-	if err != nil {
-		s.setStatus(fmt.Sprintf("[red]Unable to load buckets for %s: %v", name, err))
-		s.mutex.Lock()
-		if seq == s.bucketSeq {
-			s.bucketInfos = nil
-			s.bucketCancel = nil
-			s.bucketCluster = ""
-		}
-		s.mutex.Unlock()
-		s.queueUpdate(func() {
-			s.showBucketMessage("Unable to load buckets")
-		})
-		return
-	}
-
-	s.mutex.Lock()
-	if seq != s.bucketSeq {
-		s.mutex.Unlock()
-		return
-	}
-	s.bucketInfos = buckets
-	s.bucketCancel = nil
-	s.bucketCluster = name
 	mode := s.mode
-	currentCluster := s.currentCluster
 	s.mutex.Unlock()
+	return mode == modeLogs
+}
 
-	if mode == modeBuckets && currentCluster == name {
-		s.renderBucketTable(buckets)
-		s.setStatus(fmt.Sprintf("[green]Loaded %d bucket(s) for %s", len(buckets), name))
-	}
+func (s *uiState) focusDetailsPane() {
+	s.queueUpdate(func() {
+		s.app.SetFocus(s.detailsView)
+	})
 }
 
 func (s *uiState) setStatus(message string) {
@@ -854,6 +471,10 @@ func (s *uiState) handleSelection(row int, immediate bool) {
 		s.handleBucketSelection(row, immediate)
 		return
 	}
+	if mode == modeLogs {
+		s.handleLogSelection(row, immediate)
+		return
+	}
 	s.handleServiceSelection(row, immediate)
 }
 
@@ -873,257 +494,6 @@ func (s *uiState) queueUpdate(fn func()) {
 		}()
 		s.app.QueueUpdateDraw(fn)
 	}()
-}
-
-func (s *uiState) handleServiceSelection(row int, immediate bool) {
-	s.mutex.Lock()
-	if s.mode != modeServices {
-		if s.detailTimer != nil {
-			s.detailTimer.Stop()
-			s.detailTimer = nil
-		}
-		s.mutex.Unlock()
-		return
-	}
-	enabled := s.servicePanelVisited
-	if row <= 0 || row-1 >= len(s.currentServices) {
-		if s.detailTimer != nil {
-			s.detailTimer.Stop()
-			s.detailTimer = nil
-		}
-		s.lastSelection = ""
-		s.mutex.Unlock()
-		if enabled {
-			s.setServiceDetailsText("Select a service to inspect details")
-		}
-		return
-	}
-	svcPtr := s.currentServices[row-1]
-	if svcPtr == nil {
-		s.mutex.Unlock()
-		return
-	}
-	svc := *svcPtr
-	token := fmt.Sprintf("%s-%d-%d", svc.Name, row, s.loadSeq)
-	if s.detailTimer != nil {
-		s.detailTimer.Stop()
-		s.detailTimer = nil
-	}
-	s.lastSelection = token
-	s.mutex.Unlock()
-
-	if !enabled {
-		return
-	}
-
-	if immediate {
-		s.queueUpdate(func() {
-			s.detailsView.SetText(formatServiceDetails(&svc))
-		})
-		return
-	}
-
-	timer := time.AfterFunc(1*time.Second, func() {
-		s.mutex.Lock()
-		if s.lastSelection != token {
-			s.mutex.Unlock()
-			return
-		}
-		s.detailTimer = nil
-		s.mutex.Unlock()
-		s.queueUpdate(func() {
-			s.detailsView.SetText(formatServiceDetails(&svc))
-		})
-	})
-
-	s.mutex.Lock()
-	if s.lastSelection == token {
-		s.detailTimer = timer
-	} else {
-		timer.Stop()
-	}
-	s.mutex.Unlock()
-}
-
-func (s *uiState) handleBucketSelection(row int, immediate bool) {
-	s.mutex.Lock()
-	if s.mode != modeBuckets {
-		s.mutex.Unlock()
-		return
-	}
-	clusterName := s.currentCluster
-	var bucket *storage.BucketInfo
-	if row > 0 && row-1 < len(s.bucketInfos) {
-		bucket = s.bucketInfos[row-1]
-	}
-	s.mutex.Unlock()
-
-	if bucket == nil {
-		s.queueUpdate(func() {
-			s.detailsView.SetText("Select a bucket to inspect details")
-		})
-		s.setCurrentBucketObjectsKey("")
-		s.showBucketObjectsPrompt("Select a bucket to list objects")
-		return
-	}
-
-	s.queueUpdate(func() {
-		s.detailsView.SetText(formatBucketDetails(bucket))
-	})
-	s.setCurrentBucketObjectsKey(makeBucketObjectsKey(clusterName, bucket.Name))
-	s.presentBucketObjects(clusterName, bucket.Name)
-	if immediate {
-		s.focusBucketObjectsTable()
-	}
-}
-
-func (s *uiState) setCurrentBucketObjectsKey(key string) {
-	s.mutex.Lock()
-	s.currentBucketObjectsKey = key
-	s.mutex.Unlock()
-}
-
-func makeBucketObjectsKey(clusterName, bucketName string) string {
-	return fmt.Sprintf("%s\x00%s", clusterName, bucketName)
-}
-
-func (s *uiState) presentBucketObjects(clusterName, bucketName string) {
-	if clusterName == "" || bucketName == "" {
-		s.showBucketObjectsPrompt("Select a bucket to list objects")
-		return
-	}
-	key := makeBucketObjectsKey(clusterName, bucketName)
-	s.mutex.Lock()
-	state := s.bucketObjects[key]
-	s.mutex.Unlock()
-	if state != nil && len(state.Objects) > 0 {
-		s.renderBucketObjects(bucketName, state)
-		s.updateBucketObjectsStatus(bucketName, state)
-		return
-	}
-	s.showBucketObjectsLoading(bucketName)
-	go s.fetchBucketObjects(s.rootCtx, clusterName, bucketName, &bucketObjectRequest{})
-}
-
-func (s *uiState) toggleLegend() {
-	s.mutex.Lock()
-	visible := s.legendVisible
-	confirm := s.confirmVisible
-	s.mutex.Unlock()
-	if visible {
-		s.queueUpdate(func() {
-			s.hideLegendUnlocked()
-		})
-		return
-	}
-	if confirm || s.pages == nil {
-		return
-	}
-	s.queueUpdate(func() {
-		s.showLegendUnlocked()
-	})
-}
-
-func (s *uiState) showLegendUnlocked() {
-	if s.pages == nil {
-		return
-	}
-	s.mutex.Lock()
-	if s.legendVisible {
-		s.mutex.Unlock()
-		return
-	}
-	s.legendVisible = true
-	s.savedFocus = s.app.GetFocus()
-	s.mutex.Unlock()
-	modal := tview.NewModal().
-		SetText(legendText).
-		AddButtons([]string{"Close"})
-	modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-		s.hideLegendUnlocked()
-	})
-	s.pages.AddAndSwitchToPage("legend", modal, true)
-}
-
-func (s *uiState) hideLegendUnlocked() {
-	if s.pages == nil {
-		return
-	}
-	s.mutex.Lock()
-	if !s.legendVisible {
-		s.mutex.Unlock()
-		return
-	}
-	s.legendVisible = false
-	focus := s.savedFocus
-	s.savedFocus = nil
-	s.mutex.Unlock()
-	s.pages.RemovePage("legend")
-	if focus != nil {
-		s.app.SetFocus(focus)
-	}
-}
-
-func (s *uiState) requestDeletion() {
-	s.mutex.Lock()
-	mode := s.mode
-	if s.confirmVisible || s.legendVisible || s.pages == nil {
-		s.mutex.Unlock()
-		return
-	}
-	row, _ := s.serviceTable.GetSelection()
-	clusterName := s.currentCluster
-	switch mode {
-	case modeServices:
-		if row <= 0 || row-1 >= len(s.currentServices) || clusterName == "" {
-			s.mutex.Unlock()
-			s.setStatus("[red]Select a service to delete")
-			return
-		}
-		svcPtr := s.currentServices[row-1]
-		if svcPtr == nil {
-			s.mutex.Unlock()
-			s.setStatus("[red]Select a service to delete")
-			return
-		}
-		if s.detailTimer != nil {
-			s.detailTimer.Stop()
-			s.detailTimer = nil
-		}
-		svcName := svcPtr.Name
-		s.mutex.Unlock()
-
-		prompt := fmt.Sprintf("Delete service %q from cluster %q?", svcName, clusterName)
-		s.queueUpdate(func() {
-			s.showConfirmation(prompt, func() {
-				go s.performDeletion(clusterName, svcName)
-			})
-		})
-	case modeBuckets:
-		if row <= 0 || row-1 >= len(s.bucketInfos) || clusterName == "" {
-			s.mutex.Unlock()
-			s.setStatus("[red]Select a bucket to delete")
-			return
-		}
-		bucket := s.bucketInfos[row-1]
-		if bucket == nil || strings.TrimSpace(bucket.Name) == "" {
-			s.mutex.Unlock()
-			s.setStatus("[red]Select a bucket to delete")
-			return
-		}
-		bucketName := bucket.Name
-		s.mutex.Unlock()
-
-		prompt := fmt.Sprintf("Delete bucket %q from cluster %q?", bucketName, clusterName)
-		s.queueUpdate(func() {
-			s.showConfirmation(prompt, func() {
-				go s.performBucketDeletion(clusterName, bucketName)
-			})
-		})
-	default:
-		s.mutex.Unlock()
-		s.setStatus("[red]Deletion not available in this view")
-	}
 }
 
 func (s *uiState) showClusterInfo() {
@@ -1171,1150 +541,184 @@ func (s *uiState) showClusterInfo() {
 	}(displayName, clusterCfg)
 }
 
-func (s *uiState) promptAutoRefresh() {
-	s.mutex.Lock()
-	if s.autoRefreshPromptVisible || s.searchVisible || s.confirmVisible || s.legendVisible || s.pages == nil {
-		s.mutex.Unlock()
-		return
-	}
-	s.autoRefreshPromptVisible = true
-	s.autoRefreshFocus = s.app.GetFocus()
-	prevPeriod := s.autoRefreshPeriod
-	container := s.statusContainer
-	s.mutex.Unlock()
-
-	input := tview.NewInputField().
-		SetLabel("Auto refresh seconds (0 to stop, default 10): ").
-		SetFieldWidth(10)
-	input.SetAcceptanceFunc(func(text string, last rune) bool {
-		if last == 0 {
-			return true
-		}
-		return last >= '0' && last <= '9'
-	})
-	if prevPeriod > 0 {
-		input.SetText(fmt.Sprintf("%d", int(prevPeriod/time.Second)))
-	}
-	input.SetDoneFunc(func(key tcell.Key) {
-		switch key {
-		case tcell.KeyEnter:
-			s.handleAutoRefreshInput(input.GetText())
-		case tcell.KeyEscape:
-			s.hideAutoRefreshPrompt()
-		}
-	})
-
-	s.mutex.Lock()
-	s.autoRefreshInput = input
-	s.mutex.Unlock()
-
-	s.queueUpdate(func() {
-		container.Clear()
-		container.SetTitle("Auto Refresh")
-		input.SetBorder(false)
-		container.AddItem(input, 0, 1, true)
-	})
-	s.app.SetFocus(input)
-}
-
-func (s *uiState) hideAutoRefreshPrompt() {
-	s.mutex.Lock()
-	if !s.autoRefreshPromptVisible {
-		s.mutex.Unlock()
-		return
-	}
-	s.autoRefreshPromptVisible = false
-	input := s.autoRefreshInput
-	s.autoRefreshInput = nil
-	focus := s.autoRefreshFocus
-	s.autoRefreshFocus = nil
-	container := s.statusContainer
-	s.mutex.Unlock()
-
-	s.queueUpdate(func() {
-		container.Clear()
-		container.SetTitle("Status")
-		container.AddItem(s.statusView, 0, 1, false)
-		s.statusView.SetText(s.decorateStatusText(statusHelpText))
-	})
-	if focus != nil {
-		s.app.SetFocus(focus)
-	}
-	if input != nil {
-		input.SetText("")
-	}
-}
-
-func (s *uiState) handleAutoRefreshInput(value string) {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		s.hideAutoRefreshPrompt()
-		s.startAutoRefresh(10 * time.Second)
-		s.setStatus("[green]Auto refresh every 10 second(s)")
-		return
-	}
-	seconds, err := strconv.Atoi(trimmed)
-	if err != nil {
-		s.setStatus("[red]Enter a valid number of seconds")
-		return
-	}
-	if seconds < 0 {
-		s.setStatus("[red]Refresh period must not be negative")
-		return
-	}
-
-	s.hideAutoRefreshPrompt()
-	if seconds == 0 {
-		if s.stopAutoRefresh() {
-			s.setStatus("[yellow]Auto refresh disabled")
-		} else {
-			s.setStatus("[yellow]Auto refresh already disabled")
-		}
-		return
-	}
-
-	period := time.Duration(seconds) * time.Second
-	s.startAutoRefresh(period)
-	s.setStatus(fmt.Sprintf("[green]Auto refresh every %d second(s)", seconds))
-}
-
-func (s *uiState) startAutoRefresh(period time.Duration) {
-	if period <= 0 {
-		s.stopAutoRefresh()
-		return
-	}
-	// Ensure previous ticker is stopped.
-	s.stopAutoRefresh()
-
-	parent := context.Background()
-	s.mutex.Lock()
-	if s.rootCtx != nil {
-		parent = s.rootCtx
-	}
-	s.mutex.Unlock()
-
-	ctx, cancel := context.WithCancel(parent)
-	ticker := time.NewTicker(period)
-
-	s.mutex.Lock()
-	s.autoRefreshCancel = cancel
-	s.autoRefreshTicker = ticker
-	s.autoRefreshPeriod = period
-	s.autoRefreshActive = true
-	s.mutex.Unlock()
-
-	go func() {
-		s.refreshCurrent(context.Background())
-		for {
-			select {
-			case <-ticker.C:
-				s.refreshCurrent(context.Background())
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			}
-		}
-	}()
-}
-
-func (s *uiState) stopAutoRefresh() bool {
-	s.mutex.Lock()
-	cancel := s.autoRefreshCancel
-	active := s.autoRefreshActive
-	s.autoRefreshCancel = nil
-	s.autoRefreshTicker = nil
-	s.autoRefreshPeriod = 0
-	s.autoRefreshActive = false
-	s.mutex.Unlock()
-
-	if cancel != nil {
-		cancel()
-	}
-	return active
-}
-
-func (s *uiState) decorateStatusText(base string) string {
-	text := base
-	s.mutex.Lock()
-	active := s.autoRefreshActive
-	period := s.autoRefreshPeriod
-	s.mutex.Unlock()
-	if active && period > 0 {
-		seconds := int(period / time.Second)
-		if seconds <= 0 {
-			seconds = 1
-		}
-		indicator := fmt.Sprintf("[cyan]Auto refresh: every %d second(s)", seconds)
-		if strings.TrimSpace(text) == "" {
-			text = indicator
-		} else {
-			text = text + "\n" + indicator
-		}
-	}
-	return text
-}
-
-func (s *uiState) showServiceLogs() {
+func (s *uiState) showClusterStatus() {
 	s.mutex.Lock()
 	if s.confirmVisible || s.legendVisible {
 		s.mutex.Unlock()
 		return
 	}
-	if s.mode != modeServices {
-		s.mutex.Unlock()
-		s.setStatus("[red]Logs are only available in services view")
-		return
-	}
-	row, _ := s.serviceTable.GetSelection()
-	if row <= 0 || row-1 >= len(s.currentServices) {
-		s.mutex.Unlock()
-		s.setStatus("[red]Select a service to view logs")
-		return
-	}
-	svcPtr := s.currentServices[row-1]
 	clusterName := s.currentCluster
 	s.mutex.Unlock()
 
-	if svcPtr == nil {
-		s.setStatus("[red]Select a service to view logs")
-		return
-	}
-	serviceName := strings.TrimSpace(svcPtr.Name)
-	if serviceName == "" {
-		s.setStatus("[red]Select a service to view logs")
-		return
-	}
-
-	clusterName = strings.TrimSpace(clusterName)
-	if clusterName == "" {
-		s.setStatus("[red]Select a cluster to view logs")
+	trimmedName := strings.TrimSpace(clusterName)
+	if trimmedName == "" {
+		s.setStatus("[red]Select a cluster to view its status")
 		return
 	}
 
 	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil && trimmedName != clusterName {
+		clusterCfg = s.conf.Oscar[trimmedName]
+	}
 	if clusterCfg == nil {
-		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", trimmedName))
 		return
 	}
 
-	s.setStatus(fmt.Sprintf("[yellow]Loading logs for %q…", serviceName))
-	s.queueUpdate(func() {
-		s.detailsView.SetText(fmt.Sprintf("Loading logs for %s…", serviceName))
-	})
+	displayName := trimmedName
+	if displayName == "" {
+		displayName = clusterName
+	}
 
-	go func(cName, svcName string, cfg *cluster.Cluster) {
-		jobName, err := service.FindLatestJobName(cfg, svcName)
+	s.setStatus(fmt.Sprintf("[yellow]Loading status for cluster %q…", displayName))
+
+	go func(name string, cfg *cluster.Cluster) {
+		status, err := cfg.GetClusterStatus()
 		if err != nil {
-			if errors.Is(err, service.ErrNoLogsFound) {
-				s.setStatus(fmt.Sprintf("[yellow]No logs found for %q", svcName))
-				s.queueUpdate(func() {
-					s.detailsView.SetText(formatServiceLogs(svcName, "", ""))
-				})
-				return
-			}
-			s.setStatus(fmt.Sprintf("[red]Failed to locate logs for %q: %v", svcName, err))
+			s.setStatus(fmt.Sprintf("[red]Failed to load status for %q: %v", name, err))
 			return
 		}
-
-		logText, err := service.GetLogs(cfg, svcName, jobName, false)
-		if err != nil {
-			s.setStatus(fmt.Sprintf("[red]Failed to download logs for %q: %v", svcName, err))
-			return
-		}
-
-		s.setStatus(fmt.Sprintf("[green]Loaded logs for %q", svcName))
-		rendered := formatServiceLogs(svcName, jobName, logText)
+		s.setStatus(fmt.Sprintf("[green]Cluster status loaded for %q", name))
+		text := formatClusterStatus(name, status)
 		s.queueUpdate(func() {
-			s.detailsView.SetText(rendered)
+			s.detailsView.SetText(text)
 		})
-	}(clusterName, serviceName, clusterCfg)
+	}(displayName, clusterCfg)
 }
 
-func (s *uiState) showConfirmation(text string, onConfirm func()) {
-	if s.pages == nil {
-		return
-	}
-	s.mutex.Lock()
-	if s.confirmVisible {
-		s.mutex.Unlock()
-		return
-	}
-	s.confirmVisible = true
-	s.savedFocus = s.app.GetFocus()
-	s.mutex.Unlock()
-	modal := tview.NewModal().
-		SetText(text).
-		AddButtons([]string{"Cancel", "Delete"})
-	modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-		if buttonLabel == "Delete" {
-			onConfirm()
-		}
-		s.hideConfirmationUnlocked()
-	})
-	s.pages.AddAndSwitchToPage("confirm", modal, true)
-}
-
-func (s *uiState) hideConfirmationUnlocked() {
-	if s.pages == nil {
-		return
-	}
-	s.mutex.Lock()
-	if !s.confirmVisible {
-		s.mutex.Unlock()
-		return
-	}
-	s.confirmVisible = false
-	focus := s.savedFocus
-	s.savedFocus = nil
-	s.mutex.Unlock()
-	s.pages.RemovePage("confirm")
-	if focus != nil {
-		s.app.SetFocus(focus)
-	}
-}
-
-func (s *uiState) performDeletion(clusterName, svcName string) {
-	s.setStatus(fmt.Sprintf("[yellow]Deleting service %q...", svcName))
-	s.mutex.Lock()
-	if s.detailTimer != nil {
-		s.detailTimer.Stop()
-		s.detailTimer = nil
-	}
-	s.lastSelection = ""
-	s.mutex.Unlock()
-	clusterCfg := s.conf.Oscar[clusterName]
-	if clusterCfg == nil {
-		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
-		return
-	}
-	if err := service.RemoveService(clusterCfg, svcName); err != nil {
-		s.setStatus(fmt.Sprintf("[red]Failed to delete service %q: %v", svcName, err))
-		return
-	}
-	s.setStatus(fmt.Sprintf("[green]Service %q deleted", svcName))
-	s.setServiceDetailsText("Select a service to inspect details")
-	s.refreshCurrent(context.Background())
-}
-
-func (s *uiState) performBucketDeletion(clusterName, bucketName string) {
-	s.setStatus(fmt.Sprintf("[yellow]Deleting bucket %q...", bucketName))
-	s.mutex.Lock()
-	s.lastSelection = ""
-	s.mutex.Unlock()
-	clusterCfg := s.conf.Oscar[clusterName]
-	if clusterCfg == nil {
-		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
-		return
-	}
-	if err := storage.DeleteBucket(clusterCfg, bucketName); err != nil {
-		s.setStatus(fmt.Sprintf("[red]Failed to delete bucket %q: %v", bucketName, err))
-		return
-	}
-	s.setStatus(fmt.Sprintf("[green]Bucket %q deleted", bucketName))
-	s.queueUpdate(func() {
-		s.detailsView.SetText("Select a bucket to inspect details")
-	})
-	s.refreshCurrent(context.Background())
-}
-
-func (s *uiState) initiateSearch(ctx context.Context) {
-	_ = ctx
-	s.mutex.Lock()
-	if s.searchVisible || s.confirmVisible || s.legendVisible || s.pages == nil {
-		s.mutex.Unlock()
-		return
-	}
-	focus := s.app.GetFocus()
-	mode := s.mode
-	s.mutex.Unlock()
-
-	target := searchTargetNone
-	switch focus {
-	case s.clusterList:
-		target = searchTargetClusters
-	case s.serviceTable:
-		if mode == modeBuckets {
-			target = searchTargetBuckets
-		} else {
-			target = searchTargetServices
-		}
-	}
-
-	if target == searchTargetNone {
-		return
-	}
-
-	s.mutex.Lock()
-	switch target {
-	case searchTargetClusters:
-		if len(s.clusterNames) == 0 {
-			s.mutex.Unlock()
-			s.setStatus("[yellow]No clusters to search")
-			return
-		}
-	case searchTargetServices:
-		if len(s.currentServices) == 0 {
-			s.mutex.Unlock()
-			s.setStatus("[yellow]No services to search")
-			return
-		}
-	case searchTargetBuckets:
-		if len(s.bucketInfos) == 0 {
-			s.mutex.Unlock()
-			s.setStatus("[yellow]No buckets to search")
-			return
-		}
-	}
-	s.mutex.Unlock()
-
-	s.showSearch(target)
-}
-
-func (s *uiState) showSearch(target searchTarget) {
-	s.mutex.Lock()
-	if s.searchVisible || s.pages == nil {
-		s.mutex.Unlock()
-		return
-	}
-	s.searchVisible = true
-	s.searchTarget = target
-	s.originalFocus = s.app.GetFocus()
-	container := s.statusContainer
-	s.mutex.Unlock()
-
-	label := "Search: "
-	switch target {
-	case searchTargetClusters:
-		label = "Clusters: "
-	case searchTargetServices:
-		label = "Services: "
-	case searchTargetBuckets:
-		label = "Buckets: "
-	}
-
-	input := tview.NewInputField().
-		SetLabel(label).
-		SetFieldWidth(30)
-	input.SetChangedFunc(func(text string) {
-		s.handleSearchInput(text)
-	})
-	input.SetDoneFunc(func(key tcell.Key) {
-		s.hideSearch()
-	})
-
-	s.mutex.Lock()
-	s.searchInput = input
-	s.mutex.Unlock()
-
-	s.queueUpdate(func() {
-		container.Clear()
-		container.SetTitle("Search")
-		input.SetBorder(false)
-		container.AddItem(input, 0, 1, true)
-	})
-	s.app.SetFocus(input)
-}
-
-func (s *uiState) hideSearch() {
-	s.mutex.Lock()
-	if !s.searchVisible {
-		s.mutex.Unlock()
-		return
-	}
-	s.searchVisible = false
-	s.searchTarget = searchTargetNone
-	input := s.searchInput
-	s.searchInput = nil
-	focus := s.originalFocus
-	s.originalFocus = nil
-	container := s.statusContainer
-	s.mutex.Unlock()
-
-	s.queueUpdate(func() {
-		container.Clear()
-		container.SetTitle("Status")
-		container.AddItem(s.statusView, 0, 1, false)
-		s.statusView.SetText(s.decorateStatusText(statusHelpText))
-	})
-	if focus != nil {
-		s.app.SetFocus(focus)
-	}
-
-	if input != nil {
-		input.SetText("")
-	}
-}
-
-func (s *uiState) handleSearchInput(query string) {
-	s.mutex.Lock()
-	target := s.searchTarget
-	s.mutex.Unlock()
-	trimmed := strings.TrimSpace(query)
-	if trimmed == "" {
-		return
-	}
-	lower := strings.ToLower(trimmed)
-	var found bool
-	switch target {
-	case searchTargetClusters:
-		found = s.searchClusters(lower)
-	case searchTargetServices:
-		found = s.searchServices(lower)
-	case searchTargetBuckets:
-		found = s.searchBuckets(lower)
-	}
-	if !found {
-		s.setStatus("[yellow]No matches found")
-	}
-}
-
-func (s *uiState) searchClusters(query string) bool {
-	s.mutex.Lock()
-	names := append([]string(nil), s.clusterNames...)
-	s.mutex.Unlock()
-	for idx, name := range names {
-		if strings.Contains(strings.ToLower(name), query) {
-			s.queueUpdate(func() {
-				s.clusterList.SetCurrentItem(idx)
-			})
-			return true
-		}
-	}
-	return false
-}
-
-func (s *uiState) searchServices(query string) bool {
-	s.mutex.Lock()
-	services := append([]*types.Service(nil), s.currentServices...)
-	s.mutex.Unlock()
-	for idx, svc := range services {
-		if svc == nil {
-			continue
-		}
-		if strings.Contains(strings.ToLower(svc.Name), query) {
-			row := idx + 1
-			s.queueUpdate(func() {
-				s.serviceTable.Select(row, 0)
-				s.handleServiceSelection(row, true)
-			})
-			return true
-		}
-	}
-	return false
-}
-
-func (s *uiState) searchBuckets(query string) bool {
-	s.mutex.Lock()
-	buckets := append([]*storage.BucketInfo(nil), s.bucketInfos...)
-	s.mutex.Unlock()
-	for idx, bucket := range buckets {
-		if bucket == nil {
-			continue
-		}
-		haystack := strings.ToLower(bucket.Name + " " + bucket.Owner)
-		if strings.Contains(haystack, query) {
-			row := idx + 1
-			s.queueUpdate(func() {
-				s.serviceTable.Select(row, 0)
-				s.handleBucketSelection(row, false)
-			})
-			return true
-		}
-	}
-	return false
-}
-
-func truncateString(val string, limit int) string {
-	if limit <= 0 || len(val) <= limit {
-		return val
-	}
-	return val[:limit-1] + "…"
-}
-
-func defaultIfEmpty(val, fallback string) string {
-	if strings.TrimSpace(val) == "" {
-		return fallback
-	}
-	return val
-}
-
-func formatClusterInfo(clusterName string, info types.Info) string {
+func formatClusterStatus(clusterName string, status cluster.StatusInfo) string {
 	builder := &strings.Builder{}
 	if clusterName != "" {
 		fmt.Fprintf(builder, "[yellow]Cluster:[-] %s\n", clusterName)
 	}
-	if info.Version != "" {
-		fmt.Fprintf(builder, "[yellow]Version:[-] %s\n", info.Version)
+	if count := status.Cluster.NodesCount; count > 0 {
+		fmt.Fprintf(builder, "[yellow]Nodes:[-] %d total\n", count)
 	}
-	if info.GitCommit != "" {
-		fmt.Fprintf(builder, "[yellow]Commit:[-] %s\n", info.GitCommit)
+
+	clusterMetrics := status.Cluster.Metrics
+	if clusterMetrics.CPU.TotalFreeCores > 0 || clusterMetrics.CPU.MaxFreeOnNodeCores > 0 {
+		fmt.Fprintf(builder, "[yellow]CPU:[-] free %d cores (max node %d)\n",
+			clusterMetrics.CPU.TotalFreeCores, clusterMetrics.CPU.MaxFreeOnNodeCores)
 	}
-	if info.Architecture != "" {
-		fmt.Fprintf(builder, "[yellow]Architecture:[-] %s\n", info.Architecture)
+	if clusterMetrics.Memory.TotalFreeBytes > 0 || clusterMetrics.Memory.MaxFreeOnNodeBytes > 0 {
+		fmt.Fprintf(builder, "[yellow]Memory:[-] free %s (max node %s)\n",
+			humanizeBytes(clusterMetrics.Memory.TotalFreeBytes),
+			humanizeBytes(clusterMetrics.Memory.MaxFreeOnNodeBytes))
 	}
-	if info.KubeVersion != "" {
-		fmt.Fprintf(builder, "[yellow]Kubernetes:[-] %s\n", info.KubeVersion)
+	if clusterMetrics.GPU.TotalGPU > 0 {
+		fmt.Fprintf(builder, "[yellow]GPU:[-] %d available\n", clusterMetrics.GPU.TotalGPU)
 	}
-	if backend := info.ServerlessBackendInfo; backend != nil {
-		if backend.Name != "" {
-			fmt.Fprintf(builder, "[yellow]Serverless:[-] %s", backend.Name)
-			if backend.Version != "" {
-				fmt.Fprintf(builder, " %s", backend.Version)
+
+	if len(status.Cluster.Nodes) > 0 {
+		builder.WriteString("[yellow]Node details:[-]\n")
+		for _, node := range status.Cluster.Nodes {
+			name := defaultIfEmpty(node.Name, "node")
+			statusText := defaultIfEmpty(node.Status, "unknown")
+			role := ""
+			if node.IsInterlink {
+				role = " (interlink)"
 			}
-			builder.WriteByte('\n')
-		} else if backend.Version != "" {
-			fmt.Fprintf(builder, "[yellow]Serverless:[-] %s\n", backend.Version)
+			fmt.Fprintf(builder, "  - %s (%s)%s\n", name, statusText, role)
+			if node.CPU.CapacityCores > 0 || node.CPU.UsageCores > 0 {
+				fmt.Fprintf(builder, "      CPU: %d/%d cores used\n", node.CPU.UsageCores, node.CPU.CapacityCores)
+			}
+			if node.Memory.CapacityBytes > 0 || node.Memory.UsageBytes > 0 {
+				fmt.Fprintf(builder, "      Memory: %s/%s\n",
+					humanizeBytes(node.Memory.UsageBytes), humanizeBytes(node.Memory.CapacityBytes))
+			}
+			if node.GPU > 0 {
+				fmt.Fprintf(builder, "      GPU: %d\n", node.GPU)
+			}
+			if len(node.Conditions) > 0 {
+				conditions := make([]string, 0, len(node.Conditions))
+				for _, cond := range node.Conditions {
+					colorTag := "[green]"
+					if cond.Status {
+						colorTag = "[red]"
+					}
+					if strings.EqualFold(cond.Type, "Ready") && cond.Status {
+						colorTag = "[green]"
+					}
+					conditions = append(conditions, fmt.Sprintf("%s%s=%t[-]", colorTag, cond.Type, cond.Status))
+				}
+				fmt.Fprintf(builder, "      Conditions: %s\n", strings.Join(conditions, ", "))
+			}
 		}
 	}
+
+	oscar := status.Oscar
+	if oscar.DeploymentName != "" || oscar.JobsCount > 0 || oscar.Ready {
+		state := "not ready"
+		if oscar.Ready {
+			state = "ready"
+		}
+		fmt.Fprintf(builder, "[yellow]OSCAR:[-] %s (%s)\n", defaultIfEmpty(oscar.DeploymentName, "manager"), state)
+		deployment := oscar.Deployment
+		if deployment.Replicas > 0 || deployment.ReadyReplicas > 0 || deployment.AvailableReplicas > 0 {
+			fmt.Fprintf(builder, "    Replicas: %d total / %d ready / %d available\n",
+				deployment.Replicas, deployment.ReadyReplicas, deployment.AvailableReplicas)
+		}
+		if !deployment.CreationTimestamp.IsZero() {
+			fmt.Fprintf(builder, "    Created: %s\n", deployment.CreationTimestamp.UTC().Format(time.RFC3339))
+		}
+		if deployment.Strategy != "" {
+			fmt.Fprintf(builder, "    Strategy: %s\n", deployment.Strategy)
+		}
+		if oscar.JobsCount > 0 {
+			fmt.Fprintf(builder, "    Jobs: %d total\n", oscar.JobsCount)
+		}
+		if oscar.Pods.Total > 0 {
+			fmt.Fprintf(builder, "    Pods: %d total", oscar.Pods.Total)
+			if len(oscar.Pods.States) > 0 {
+				stateKeys := make([]string, 0, len(oscar.Pods.States))
+				for key := range oscar.Pods.States {
+					stateKeys = append(stateKeys, key)
+				}
+				sort.Strings(stateKeys)
+				parts := make([]string, 0, len(stateKeys))
+				for _, key := range stateKeys {
+					parts = append(parts, fmt.Sprintf("%s=%d", key, oscar.Pods.States[key]))
+				}
+				fmt.Fprintf(builder, " (%s)", strings.Join(parts, ", "))
+			}
+			builder.WriteByte('\n')
+		}
+		if oscar.OIDC.Enabled || len(oscar.OIDC.Issuers) > 0 || len(oscar.OIDC.Groups) > 0 {
+			fmt.Fprintf(builder, "    OIDC: enabled=%t\n", oscar.OIDC.Enabled)
+			if len(oscar.OIDC.Issuers) > 0 {
+				fmt.Fprintf(builder, "          issuers: %s\n", strings.Join(oscar.OIDC.Issuers, ", "))
+			}
+			if len(oscar.OIDC.Groups) > 0 {
+				fmt.Fprintf(builder, "          groups: %s\n", strings.Join(oscar.OIDC.Groups, ", "))
+			}
+		}
+	}
+
+	minio := status.MinIO
+	if minio.BucketsCount > 0 || minio.TotalObjects > 0 {
+		fmt.Fprintf(builder, "[yellow]MinIO:[-] %d bucket(s), %d object(s)\n", minio.BucketsCount, minio.TotalObjects)
+	}
+
 	out := strings.TrimRight(builder.String(), "\n")
 	if out == "" {
-		return "No cluster information available"
+		return "No cluster status available"
 	}
 	return out
 }
 
-func formatServiceLogs(serviceName, jobName, logs string) string {
-	builder := &strings.Builder{}
-	if serviceName != "" {
-		fmt.Fprintf(builder, "[yellow]Service:[-] %s\n", serviceName)
+func humanizeBytes(value int64) string {
+	if value <= 0 {
+		return "0 B"
 	}
-	if jobName != "" {
-		fmt.Fprintf(builder, "[yellow]Job:[-] %s\n", jobName)
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB"}
+	f := float64(value)
+	idx := 0
+	for f >= 1024 && idx < len(units)-1 {
+		f /= 1024
+		idx++
 	}
-	clean := strings.TrimSpace(logs)
-	if clean == "" {
-		builder.WriteString("No logs available")
-		return builder.String()
+	if f >= 10 || idx == 0 {
+		return fmt.Sprintf("%.0f %s", f, units[idx])
 	}
-	builder.WriteString("\n")
-	builder.WriteString(tview.Escape(clean))
-	return builder.String()
-}
-
-func formatClusterConfig(name string, cfg *cluster.Cluster) string {
-	title := strings.TrimSpace(name)
-	if title == "" {
-		title = "Cluster"
-	}
-	if cfg == nil {
-		return fmt.Sprintf("[yellow]%s:[-]\n    configuration not available", title)
-	}
-
-	builder := &strings.Builder{}
-	fmt.Fprintf(builder, "[yellow]%s:[-]\n", title)
-	appendField := func(label, value string) {
-		if strings.TrimSpace(value) == "" {
-			return
-		}
-		fmt.Fprintf(builder, "    %s: %s\n", label, value)
-	}
-
-	appendField("endpoint", cfg.Endpoint)
-	appendField("auth_user", cfg.AuthUser)
-	if cfg.AuthPassword != "" {
-		appendField("auth_password", maskSecret(cfg.AuthPassword))
-	}
-	appendField("oidc_account_name", cfg.OIDCAccountName)
-	if cfg.OIDCRefreshToken != "" {
-		appendField("oidc_refresh_token", trimToken(cfg.OIDCRefreshToken))
-	}
-	appendField("ssl_verify", strconv.FormatBool(cfg.SSLVerify))
-	appendField("memory", strings.TrimSpace(cfg.Memory))
-	appendField("log_level", strings.TrimSpace(cfg.LogLevel))
-
-	return strings.TrimRight(builder.String(), "\n")
-}
-
-func maskSecret(secret string) string {
-	if secret == "" {
-		return ""
-	}
-	const maxStars = 8
-	if len(secret) <= maxStars {
-		return strings.Repeat("*", len(secret))
-	}
-	return strings.Repeat("*", maxStars)
-}
-
-func trimToken(token string) string {
-	if token == "" {
-		return ""
-	}
-	firstLine := strings.Split(token, "\n")[0]
-	const limit = 64
-	if len(firstLine) > limit {
-		return firstLine[:limit]
-	}
-	return firstLine
-}
-
-func formatServiceDetails(svc *types.Service) string {
-	if svc == nil {
-		return ""
-	}
-	builder := &strings.Builder{}
-	fmt.Fprintf(builder, "[yellow]Name:[-] %s\n", svc.Name)
-	if svc.ClusterID != "" {
-		fmt.Fprintf(builder, "[yellow]Cluster:[-] %s\n", svc.ClusterID)
-	}
-	if svc.Image != "" {
-		fmt.Fprintf(builder, "[yellow]Image:[-] %s\n", svc.Image)
-	}
-	if svc.Memory != "" {
-		fmt.Fprintf(builder, "[yellow]Memory:[-] %s\n", svc.Memory)
-	}
-	if svc.CPU != "" {
-		fmt.Fprintf(builder, "[yellow]CPU:[-] %s\n", svc.CPU)
-	}
-	if replicas := len(svc.Replicas); replicas > 0 {
-		fmt.Fprintf(builder, "[yellow]Replicas:[-] %d\n", replicas)
-	}
-	if svc.LogLevel != "" {
-		fmt.Fprintf(builder, "[yellow]Log Level:[-] %s\n", svc.LogLevel)
-	}
-	return builder.String()
-}
-
-func formatBucketDetails(bucket *storage.BucketInfo) string {
-	if bucket == nil {
-		return ""
-	}
-	builder := &strings.Builder{}
-	fmt.Fprintf(builder, "[yellow]Name:[-] %s\n", bucket.Name)
-	if bucket.Visibility != "" {
-		fmt.Fprintf(builder, "[yellow]Visibility:[-] %s\n", bucket.Visibility)
-	}
-	if len(bucket.AllowedUsers) > 0 {
-		fmt.Fprintf(builder, "[yellow]Allowed Users:[-] %s\n", strings.Join(bucket.AllowedUsers, ", "))
-	}
-	if bucket.Owner != "" {
-		fmt.Fprintf(builder, "[yellow]Owner:[-] %s\n", bucket.Owner)
-	}
-
-	/*if !bucket.CreationDate.IsZero() {
-		fmt.Fprintf(builder, "[yellow]Created:[-] %s\n", bucket.CreationDate.Format("2006-01-02 15:04"))
-	}*/
-	return builder.String()
-}
-
-func (s *uiState) showServiceMessage(message string) {
-	s.serviceTable.SetTitle("Services")
-	setServiceTableHeader(s.serviceTable)
-	fillMessageRow(s.serviceTable, len(serviceHeaders), message)
-}
-
-func (s *uiState) showBucketMessage(message string) {
-	s.serviceTable.SetTitle("Buckets")
-	setBucketTableHeader(s.serviceTable)
-	fillMessageRow(s.serviceTable, len(bucketHeaders), message)
-}
-
-func (s *uiState) renderServiceTable(services []*types.Service) {
-	s.queueUpdate(func() {
-		s.serviceTable.SetTitle("Services")
-		setServiceTableHeader(s.serviceTable)
-		if len(services) == 0 {
-			fillMessageRow(s.serviceTable, len(serviceHeaders), "No services found")
-			return
-		}
-		for i, svc := range services {
-			row := i + 1
-			s.serviceTable.SetCell(row, 0, tview.NewTableCell(svc.Name).
-				SetExpansion(2).
-				SetSelectable(true)).
-				SetCell(row, 1, tview.NewTableCell(truncateString(svc.Image, 40)).
-					SetExpansion(4)).
-				SetCell(row, 2, tview.NewTableCell(defaultIfEmpty(svc.CPU, "-")).
-					SetExpansion(1)).
-				SetCell(row, 3, tview.NewTableCell(defaultIfEmpty(svc.Memory, "-")).
-					SetExpansion(1))
-		}
-		row, col := s.serviceTable.GetSelection()
-		if row <= 0 || row > len(services) {
-			s.serviceTable.Select(1, 0)
-		} else {
-			s.serviceTable.Select(row, col)
-		}
-	})
-}
-
-func (s *uiState) renderBucketTable(buckets []*storage.BucketInfo) {
-	s.queueUpdate(func() {
-		s.serviceTable.SetTitle("Buckets")
-		setBucketTableHeader(s.serviceTable)
-		if len(buckets) == 0 {
-			fillMessageRow(s.serviceTable, len(bucketHeaders), "No buckets found")
-			s.detailsView.SetText("Select a bucket to inspect details")
-			s.showBucketObjectsPrompt("Select a bucket to list objects")
-			return
-		}
-		for i, bucket := range buckets {
-			row := i + 1
-			color := bucketVisibilityColor(bucket.Visibility)
-			nameCell := tview.NewTableCell(bucket.Name).
-				SetSelectable(true).
-				SetExpansion(4)
-			visCell := tview.NewTableCell(defaultIfEmpty(bucket.Visibility, "-")).
-				SetExpansion(2).
-				SetTextColor(color)
-			ownerCell := tview.NewTableCell(defaultIfEmpty(bucket.Owner, "-")).
-				SetExpansion(5)
-			s.serviceTable.SetCell(row, 0, nameCell).
-				SetCell(row, 1, visCell).
-				SetCell(row, 2, ownerCell)
-		}
-		row, col := s.serviceTable.GetSelection()
-		if row <= 0 || row > len(buckets) {
-			s.serviceTable.Select(1, 0)
-		} else {
-			s.serviceTable.Select(row, col)
-		}
-	})
-}
-
-func setServiceTableHeader(table *tview.Table) {
-	setTableHeader(table, serviceHeaders)
-}
-
-func setBucketTableHeader(table *tview.Table) {
-	setTableHeader(table, bucketHeaders)
-}
-
-func setBucketObjectTableHeader(table *tview.Table) {
-	setTableHeader(table, bucketObjectHeaders)
-}
-
-func setTableHeader(table *tview.Table, headers []string) {
-	table.Clear()
-	for col, header := range headers {
-		table.SetCell(0, col, tview.NewTableCell(header).
-			SetTextColor(tcell.ColorWhite).
-			SetSelectable(false).
-			SetAttributes(tcell.AttrBold))
-	}
-}
-
-func fillMessageRow(table *tview.Table, columns int, message string) {
-	table.SetCell(1, 0, tview.NewTableCell(message).
-		SetAlign(tview.AlignCenter).
-		SetSelectable(false).
-		SetExpansion(columns))
-	for col := 1; col < columns; col++ {
-		table.SetCell(1, col, tview.NewTableCell("").SetSelectable(false))
-	}
-}
-
-func bucketVisibilityColor(vis string) tcell.Color {
-	switch strings.ToLower(strings.TrimSpace(vis)) {
-	case "restricted":
-		return tcell.ColorYellow
-	case "private":
-		return tcell.ColorRed
-	case "public":
-		return tcell.ColorGreen
-	default:
-		return tcell.ColorWhite
-	}
-}
-
-func (s *uiState) ensureBucketObjectsPaneUnlocked() {
-	if s.bucketObjectsVisible {
-		return
-	}
-	s.bucketObjectsVisible = true
-	s.detailContainer.AddItem(s.bucketObjectsTable, 0, 2, false)
-}
-
-func (s *uiState) hideBucketObjectsPane() {
-	s.queueUpdate(func() {
-		if !s.bucketObjectsVisible {
-			return
-		}
-		s.bucketObjectsVisible = false
-		s.detailContainer.RemoveItem(s.bucketObjectsTable)
-	})
-}
-
-func (s *uiState) focusBucketObjectsTable() {
-	s.queueUpdate(func() {
-		s.ensureBucketObjectsPaneUnlocked()
-		rowCount := s.bucketObjectsTable.GetRowCount()
-		if rowCount > 1 {
-			row, _ := s.bucketObjectsTable.GetSelection()
-			if row <= 0 || row >= rowCount {
-				s.bucketObjectsTable.Select(1, 0)
-			}
-		}
-		s.app.SetFocus(s.bucketObjectsTable)
-	})
-}
-
-func (s *uiState) showBucketObjectsPrompt(message string) {
-	s.queueUpdate(func() {
-		s.ensureBucketObjectsPaneUnlocked()
-		s.bucketObjectsTable.SetTitle("Bucket Objects")
-		setBucketObjectTableHeader(s.bucketObjectsTable)
-		fillMessageRow(s.bucketObjectsTable, len(bucketObjectHeaders), message)
-		s.bucketObjectsTable.Select(0, 0)
-	})
-}
-
-func (s *uiState) showBucketObjectsLoading(bucketName string) {
-	title := "Bucket Objects"
-	if bucketName != "" {
-		title = fmt.Sprintf("Bucket Objects (%s)", bucketName)
-	}
-	s.queueUpdate(func() {
-		s.ensureBucketObjectsPaneUnlocked()
-		s.bucketObjectsTable.SetTitle(title)
-		setBucketObjectTableHeader(s.bucketObjectsTable)
-		fillMessageRow(s.bucketObjectsTable, len(bucketObjectHeaders), "Loading objects…")
-		s.bucketObjectsTable.Select(0, 0)
-	})
-}
-
-func (s *uiState) showBucketObjectsError(bucketName string) {
-	title := "Bucket Objects"
-	if bucketName != "" {
-		title = fmt.Sprintf("Bucket Objects (%s)", bucketName)
-	}
-	s.queueUpdate(func() {
-		s.ensureBucketObjectsPaneUnlocked()
-		s.bucketObjectsTable.SetTitle(title)
-		setBucketObjectTableHeader(s.bucketObjectsTable)
-		fillMessageRow(s.bucketObjectsTable, len(bucketObjectHeaders), "Unable to load objects")
-		s.bucketObjectsTable.Select(0, 0)
-	})
-}
-
-func (s *uiState) renderBucketObjects(bucketName string, state *bucketObjectState) {
-	if state == nil {
-		s.showBucketObjectsPrompt("Select a bucket to list objects")
-		return
-	}
-	title := "Bucket Objects"
-	if bucketName != "" {
-		title = fmt.Sprintf("Bucket Objects (%s)", bucketName)
-	}
-	if state.Auto {
-		title += " [all]"
-	}
-	s.queueUpdate(func() {
-		s.ensureBucketObjectsPaneUnlocked()
-		s.bucketObjectsTable.SetTitle(title)
-		setBucketObjectTableHeader(s.bucketObjectsTable)
-		if len(state.Objects) == 0 {
-			fillMessageRow(s.bucketObjectsTable, len(bucketObjectHeaders), "No objects found")
-			s.bucketObjectsTable.Select(0, 0)
-			return
-		}
-		for i, obj := range state.Objects {
-			row := i + 1
-			lastModified := "-"
-			if !obj.LastModified.IsZero() {
-				lastModified = obj.LastModified.Format("2006-01-02 15:04:05")
-			}
-			s.bucketObjectsTable.SetCell(row, 0, tview.NewTableCell(obj.Name).
-				SetSelectable(true).
-				SetExpansion(5)).
-				SetCell(row, 1, tview.NewTableCell(strconv.FormatInt(obj.Size, 10)).
-					SetSelectable(false).
-					SetExpansion(2)).
-				SetCell(row, 2, tview.NewTableCell(lastModified).
-					SetSelectable(false).
-					SetExpansion(3))
-		}
-		row, _ := s.bucketObjectsTable.GetSelection()
-		if row <= 0 || row > len(state.Objects) {
-			s.bucketObjectsTable.Select(1, 0)
-		}
-	})
-}
-
-func (s *uiState) updateBucketObjectsStatus(bucketName string, state *bucketObjectState) {
-	if state == nil {
-		return
-	}
-	count := len(state.Objects)
-	if state.Auto {
-		s.setStatus(fmt.Sprintf("[green]Loaded %d object(s) from %s", count, bucketName))
-		return
-	}
-	if state.NextPage != "" && state.IsTruncated {
-		msg := fmt.Sprintf("[yellow]%s: showing %d object(s). Press 'n' for next page", bucketName, count)
-		if len(state.PrevTokens) > 0 {
-			msg += ", 'p' for previous"
-		}
-		s.setStatus(msg)
-		return
-	}
-	if len(state.PrevTokens) > 0 {
-		s.setStatus(fmt.Sprintf("[green]%s: showing %d object(s). Press 'p' for previous page", bucketName, count))
-		return
-	}
-	s.setStatus(fmt.Sprintf("[green]%s: showing %d object(s)", bucketName, count))
-}
-
-func (s *uiState) currentBucketSelection() (string, *storage.BucketInfo) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	if s.mode != modeBuckets {
-		return "", nil
-	}
-	clusterName := s.currentCluster
-	row, _ := s.serviceTable.GetSelection()
-	if row <= 0 || row-1 >= len(s.bucketInfos) {
-		return clusterName, nil
-	}
-	return clusterName, s.bucketInfos[row-1]
-}
-
-func (s *uiState) reloadBucketObjects(ctx context.Context) {
-	clusterName, bucket := s.currentBucketSelection()
-	if clusterName == "" || bucket == nil {
-		s.setStatus("[yellow]Select a bucket to reload objects")
-		return
-	}
-	s.setCurrentBucketObjectsKey(makeBucketObjectsKey(clusterName, bucket.Name))
-	s.showBucketObjectsLoading(bucket.Name)
-	go s.fetchBucketObjects(ctx, clusterName, bucket.Name, &bucketObjectRequest{})
-}
-
-func (s *uiState) nextBucketObjectsPage(ctx context.Context) {
-	clusterName, bucket := s.currentBucketSelection()
-	if clusterName == "" || bucket == nil {
-		s.setStatus("[yellow]Select a bucket to load more objects")
-		return
-	}
-	key := makeBucketObjectsKey(clusterName, bucket.Name)
-	s.mutex.Lock()
-	state := s.bucketObjects[key]
-	s.mutex.Unlock()
-	if state == nil || state.NextPage == "" {
-		s.setStatus(fmt.Sprintf("[yellow]No additional objects for %s", bucket.Name))
-		return
-	}
-	prevTokens := append([]string(nil), state.PrevTokens...)
-	prevTokens = append(prevTokens, state.CurrentToken)
-	s.setCurrentBucketObjectsKey(key)
-	s.showBucketObjectsLoading(bucket.Name)
-	go s.fetchBucketObjects(ctx, clusterName, bucket.Name, &bucketObjectRequest{
-		Token:      state.NextPage,
-		PrevTokens: prevTokens,
-	})
-}
-
-func (s *uiState) previousBucketObjectsPage(ctx context.Context) {
-	clusterName, bucket := s.currentBucketSelection()
-	if clusterName == "" || bucket == nil {
-		s.setStatus("[yellow]Select a bucket to load previous objects")
-		return
-	}
-	key := makeBucketObjectsKey(clusterName, bucket.Name)
-	s.mutex.Lock()
-	state := s.bucketObjects[key]
-	s.mutex.Unlock()
-	if state == nil || len(state.PrevTokens) == 0 {
-		s.setStatus(fmt.Sprintf("[yellow]%s is already at the first page", bucket.Name))
-		return
-	}
-	prevTokens := append([]string(nil), state.PrevTokens...)
-	token := prevTokens[len(prevTokens)-1]
-	prevTokens = prevTokens[:len(prevTokens)-1]
-	s.setCurrentBucketObjectsKey(key)
-	s.showBucketObjectsLoading(bucket.Name)
-	go s.fetchBucketObjects(ctx, clusterName, bucket.Name, &bucketObjectRequest{
-		Token:      token,
-		PrevTokens: prevTokens,
-	})
-}
-
-func (s *uiState) loadAllBucketObjects(ctx context.Context) {
-	clusterName, bucket := s.currentBucketSelection()
-	if clusterName == "" || bucket == nil {
-		s.setStatus("[yellow]Select a bucket to load all objects")
-		return
-	}
-	s.setCurrentBucketObjectsKey(makeBucketObjectsKey(clusterName, bucket.Name))
-	s.showBucketObjectsLoading(bucket.Name)
-	go s.fetchBucketObjects(ctx, clusterName, bucket.Name, &bucketObjectRequest{
-		Token: "",
-		Auto:  true,
-	})
-}
-
-func (s *uiState) fetchBucketObjects(ctx context.Context, clusterName, bucketName string, req *bucketObjectRequest) {
-	if req == nil {
-		req = &bucketObjectRequest{}
-	}
-	clusterCfg := s.conf.Oscar[clusterName]
-	if clusterCfg == nil {
-		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
-		s.showBucketObjectsError(bucketName)
-		return
-	}
-
-	opts := &storage.BucketListOptions{
-		PageToken:    strings.TrimSpace(req.Token),
-		AutoPaginate: req.Auto,
-	}
-	key := makeBucketObjectsKey(clusterName, bucketName)
-
-	s.mutex.Lock()
-	if s.bucketObjectsCancel != nil {
-		s.bucketObjectsCancel()
-	}
-	s.bucketObjectsSeq++
-	seq := s.bucketObjectsSeq
-	ctxFetch, cancel := context.WithTimeout(ctx, 20*time.Second)
-	s.bucketObjectsCancel = cancel
-	s.mutex.Unlock()
-
-	result, err := storage.ListBucketObjectsWithOptionsContext(ctxFetch, clusterCfg, bucketName, opts)
-	cancel()
-
-	if err != nil {
-		s.mutex.Lock()
-		if seq == s.bucketObjectsSeq {
-			s.bucketObjectsCancel = nil
-		}
-		activeKey := s.currentBucketObjectsKey
-		s.mutex.Unlock()
-		s.setStatus(fmt.Sprintf("[red]Unable to load objects for %s: %v", bucketName, err))
-		if activeKey == key {
-			s.showBucketObjectsError(bucketName)
-		}
-		return
-	}
-
-	if result == nil {
-		result = &storage.BucketListResult{}
-	}
-	state := &bucketObjectState{
-		Objects:       append([]*storage.BucketObject(nil), result.Objects...),
-		NextPage:      result.NextPage,
-		PrevTokens:    append([]string(nil), req.PrevTokens...),
-		CurrentToken:  opts.PageToken,
-		IsTruncated:   result.IsTruncated,
-		Auto:          opts.AutoPaginate,
-		ReturnedItems: result.ReturnedItems,
-	}
-	if state.Objects == nil {
-		state.Objects = []*storage.BucketObject{}
-	}
-
-	s.mutex.Lock()
-	if seq != s.bucketObjectsSeq {
-		s.mutex.Unlock()
-		return
-	}
-	s.bucketObjectsCancel = nil
-	s.bucketObjects[key] = state
-	activeKey := s.currentBucketObjectsKey
-	s.mutex.Unlock()
-
-	if activeKey == key {
-		s.renderBucketObjects(bucketName, state)
-		s.updateBucketObjectsStatus(bucketName, state)
-	}
+	return fmt.Sprintf("%.1f %s", f, units[idx])
 }

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -192,6 +192,11 @@ func Run(ctx context.Context, conf *config.Config) error {
 				state.switchToLogs(ctx)
 				return nil
 			}
+		case tcell.KeyDelete:
+			if app.GetFocus() == state.serviceTable && (state.modeIsServices() || state.modeIsBuckets()) {
+				state.requestDeletion()
+				return nil
+			}
 		}
 
 		switch event.Rune() {
@@ -232,7 +237,7 @@ func Run(ctx context.Context, conf *config.Config) error {
 				return nil
 			}
 		case 'd', 'D':
-			if app.GetFocus() == state.serviceTable && state.modeIsServices() {
+			if app.GetFocus() == state.serviceTable && (state.modeIsServices() || state.modeIsBuckets()) {
 				state.requestDeletion()
 				return nil
 			}

--- a/pkg/tui/auto_refresh.go
+++ b/pkg/tui/auto_refresh.go
@@ -1,0 +1,195 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func (s *uiState) promptAutoRefresh() {
+	s.mutex.Lock()
+	if s.autoRefreshPromptVisible || s.searchVisible || s.confirmVisible || s.legendVisible || s.pages == nil {
+		s.mutex.Unlock()
+		return
+	}
+	s.autoRefreshPromptVisible = true
+	s.autoRefreshFocus = s.app.GetFocus()
+	prevPeriod := s.autoRefreshPeriod
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	input := tview.NewInputField().
+		SetLabel("Auto refresh seconds (0 to stop, default 10): ").
+		SetFieldWidth(10)
+	input.SetAcceptanceFunc(func(text string, last rune) bool {
+		if last == 0 {
+			return true
+		}
+		return last >= '0' && last <= '9'
+	})
+	if prevPeriod > 0 {
+		input.SetText(fmt.Sprintf("%d", int(prevPeriod/time.Second)))
+	}
+	input.SetDoneFunc(func(key tcell.Key) {
+		switch key {
+		case tcell.KeyEnter:
+			s.handleAutoRefreshInput(input.GetText())
+		case tcell.KeyEscape:
+			s.hideAutoRefreshPrompt()
+		}
+	})
+
+	s.mutex.Lock()
+	s.autoRefreshInput = input
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Auto Refresh")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) hideAutoRefreshPrompt() {
+	s.mutex.Lock()
+	if !s.autoRefreshPromptVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.autoRefreshPromptVisible = false
+	input := s.autoRefreshInput
+	s.autoRefreshInput = nil
+	focus := s.autoRefreshFocus
+	s.autoRefreshFocus = nil
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Status")
+		container.AddItem(s.statusView, 0, 1, false)
+		s.statusView.SetText(s.decorateStatusText(statusHelpText))
+	})
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
+	if input != nil {
+		input.SetText("")
+	}
+}
+
+func (s *uiState) handleAutoRefreshInput(value string) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		s.hideAutoRefreshPrompt()
+		s.startAutoRefresh(10 * time.Second)
+		s.setStatus("[green]Auto refresh every 10 second(s)")
+		return
+	}
+	seconds, err := strconv.Atoi(trimmed)
+	if err != nil {
+		s.setStatus("[red]Enter a valid number of seconds")
+		return
+	}
+	if seconds < 0 {
+		s.setStatus("[red]Refresh period must not be negative")
+		return
+	}
+
+	s.hideAutoRefreshPrompt()
+	if seconds == 0 {
+		if s.stopAutoRefresh() {
+			s.setStatus("[yellow]Auto refresh disabled")
+		} else {
+			s.setStatus("[yellow]Auto refresh already disabled")
+		}
+		return
+	}
+
+	period := time.Duration(seconds) * time.Second
+	s.startAutoRefresh(period)
+	s.setStatus(fmt.Sprintf("[green]Auto refresh every %d second(s)", seconds))
+}
+
+func (s *uiState) startAutoRefresh(period time.Duration) {
+	if period <= 0 {
+		s.stopAutoRefresh()
+		return
+	}
+	// Ensure previous ticker is stopped.
+	s.stopAutoRefresh()
+
+	parent := context.Background()
+	s.mutex.Lock()
+	if s.rootCtx != nil {
+		parent = s.rootCtx
+	}
+	s.mutex.Unlock()
+
+	ctx, cancel := context.WithCancel(parent)
+	ticker := time.NewTicker(period)
+
+	s.mutex.Lock()
+	s.autoRefreshCancel = cancel
+	s.autoRefreshTicker = ticker
+	s.autoRefreshPeriod = period
+	s.autoRefreshActive = true
+	s.mutex.Unlock()
+
+	go func() {
+		s.refreshCurrent(context.Background())
+		for {
+			select {
+			case <-ticker.C:
+				s.refreshCurrent(context.Background())
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (s *uiState) stopAutoRefresh() bool {
+	s.mutex.Lock()
+	cancel := s.autoRefreshCancel
+	active := s.autoRefreshActive
+	s.autoRefreshCancel = nil
+	s.autoRefreshTicker = nil
+	s.autoRefreshPeriod = 0
+	s.autoRefreshActive = false
+	s.mutex.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	return active
+}
+
+func (s *uiState) decorateStatusText(base string) string {
+	text := base
+	s.mutex.Lock()
+	active := s.autoRefreshActive
+	period := s.autoRefreshPeriod
+	s.mutex.Unlock()
+	if active && period > 0 {
+		seconds := int(period / time.Second)
+		if seconds <= 0 {
+			seconds = 1
+		}
+		indicator := fmt.Sprintf("[cyan]Auto refresh: every %d second(s)", seconds)
+		if strings.TrimSpace(text) == "" {
+			text = indicator
+		} else {
+			text = text + "\n" + indicator
+		}
+	}
+	return text
+}

--- a/pkg/tui/bucket_objects.go
+++ b/pkg/tui/bucket_objects.go
@@ -1,0 +1,343 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rivo/tview"
+
+	"github.com/grycap/oscar-cli/pkg/storage"
+)
+
+func (s *uiState) setCurrentBucketObjectsKey(key string) {
+	s.mutex.Lock()
+	s.currentBucketObjectsKey = key
+	s.mutex.Unlock()
+}
+
+func makeBucketObjectsKey(clusterName, bucketName string) string {
+	return fmt.Sprintf("%s\x00%s", clusterName, bucketName)
+}
+
+func (s *uiState) presentBucketObjects(clusterName, bucketName string) {
+	if clusterName == "" || bucketName == "" {
+		s.showBucketObjectsPrompt("Select a bucket to list objects")
+		return
+	}
+	key := makeBucketObjectsKey(clusterName, bucketName)
+	s.mutex.Lock()
+	state := s.bucketObjects[key]
+	s.mutex.Unlock()
+	if state != nil && len(state.Objects) > 0 {
+		s.renderBucketObjects(bucketName, state)
+		s.updateBucketObjectsStatus(bucketName, state)
+		return
+	}
+	s.showBucketObjectsLoading(bucketName)
+	go s.fetchBucketObjects(s.rootCtx, clusterName, bucketName, &bucketObjectRequest{})
+}
+
+func (s *uiState) ensureBucketObjectsPaneUnlocked() {
+	if s.bucketObjectsVisible {
+		return
+	}
+	s.bucketObjectsVisible = true
+	s.detailContainer.AddItem(s.bucketObjectsTable, 0, 2, false)
+}
+
+func (s *uiState) hideBucketObjectsPane() {
+	s.queueUpdate(func() {
+		if !s.bucketObjectsVisible {
+			return
+		}
+		s.bucketObjectsVisible = false
+		s.detailContainer.RemoveItem(s.bucketObjectsTable)
+	})
+}
+
+func (s *uiState) focusBucketObjectsTable() {
+	s.queueUpdate(func() {
+		s.ensureBucketObjectsPaneUnlocked()
+		rowCount := s.bucketObjectsTable.GetRowCount()
+		if rowCount > 1 {
+			row, _ := s.bucketObjectsTable.GetSelection()
+			if row <= 0 || row >= rowCount {
+				s.bucketObjectsTable.Select(1, 0)
+			}
+		}
+		s.app.SetFocus(s.bucketObjectsTable)
+	})
+}
+
+func (s *uiState) showBucketObjectsPrompt(message string) {
+	s.queueUpdate(func() {
+		s.ensureBucketObjectsPaneUnlocked()
+		s.bucketObjectsTable.SetTitle("Bucket Objects")
+		setBucketObjectTableHeader(s.bucketObjectsTable)
+		fillMessageRow(s.bucketObjectsTable, len(bucketObjectHeaders), message)
+		s.bucketObjectsTable.Select(0, 0)
+	})
+}
+
+func (s *uiState) showBucketObjectsLoading(bucketName string) {
+	title := "Bucket Objects"
+	if bucketName != "" {
+		title = fmt.Sprintf("Bucket Objects (%s)", bucketName)
+	}
+	s.queueUpdate(func() {
+		s.ensureBucketObjectsPaneUnlocked()
+		s.bucketObjectsTable.SetTitle(title)
+		setBucketObjectTableHeader(s.bucketObjectsTable)
+		fillMessageRow(s.bucketObjectsTable, len(bucketObjectHeaders), "Loading objects…")
+		s.bucketObjectsTable.Select(0, 0)
+	})
+}
+
+func (s *uiState) showBucketObjectsError(bucketName string) {
+	title := "Bucket Objects"
+	if bucketName != "" {
+		title = fmt.Sprintf("Bucket Objects (%s)", bucketName)
+	}
+	s.queueUpdate(func() {
+		s.ensureBucketObjectsPaneUnlocked()
+		s.bucketObjectsTable.SetTitle(title)
+		setBucketObjectTableHeader(s.bucketObjectsTable)
+		fillMessageRow(s.bucketObjectsTable, len(bucketObjectHeaders), "Unable to load objects")
+		s.bucketObjectsTable.Select(0, 0)
+	})
+}
+
+func (s *uiState) renderBucketObjects(bucketName string, state *bucketObjectState) {
+	if state == nil {
+		s.showBucketObjectsPrompt("Select a bucket to list objects")
+		return
+	}
+	title := "Bucket Objects"
+	if bucketName != "" {
+		title = fmt.Sprintf("Bucket Objects (%s)", bucketName)
+	}
+	if state.Auto {
+		title += " [all]"
+	}
+	s.queueUpdate(func() {
+		s.ensureBucketObjectsPaneUnlocked()
+		s.bucketObjectsTable.SetTitle(title)
+		setBucketObjectTableHeader(s.bucketObjectsTable)
+		if len(state.Objects) == 0 {
+			fillMessageRow(s.bucketObjectsTable, len(bucketObjectHeaders), "No objects found")
+			s.bucketObjectsTable.Select(0, 0)
+			return
+		}
+		for i, obj := range state.Objects {
+			row := i + 1
+			lastModified := "-"
+			if !obj.LastModified.IsZero() {
+				lastModified = obj.LastModified.Format("2006-01-02 15:04:05")
+			}
+			s.bucketObjectsTable.SetCell(row, 0, tview.NewTableCell(obj.Name).
+				SetSelectable(true).
+				SetExpansion(5)).
+				SetCell(row, 1, tview.NewTableCell(strconv.FormatInt(obj.Size, 10)).
+					SetSelectable(false).
+					SetExpansion(2)).
+				SetCell(row, 2, tview.NewTableCell(lastModified).
+					SetSelectable(false).
+					SetExpansion(3))
+		}
+		row, _ := s.bucketObjectsTable.GetSelection()
+		if row <= 0 || row > len(state.Objects) {
+			s.bucketObjectsTable.Select(1, 0)
+		}
+	})
+}
+
+func (s *uiState) updateBucketObjectsStatus(bucketName string, state *bucketObjectState) {
+	if state == nil {
+		return
+	}
+	count := len(state.Objects)
+	if state.Auto {
+		s.setStatus(fmt.Sprintf("[green]Loaded %d object(s) from %s", count, bucketName))
+		return
+	}
+	if state.NextPage != "" && state.IsTruncated {
+		msg := fmt.Sprintf("[yellow]%s: showing %d object(s). Press 'n' for next page", bucketName, count)
+		if len(state.PrevTokens) > 0 {
+			msg += ", 'p' for previous"
+		}
+		s.setStatus(msg)
+		return
+	}
+	if len(state.PrevTokens) > 0 {
+		s.setStatus(fmt.Sprintf("[green]%s: showing %d object(s). Press 'p' for previous page", bucketName, count))
+		return
+	}
+	s.setStatus(fmt.Sprintf("[green]%s: showing %d object(s)", bucketName, count))
+}
+
+func (s *uiState) currentBucketSelection() (string, *storage.BucketInfo) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.mode != modeBuckets {
+		return "", nil
+	}
+	clusterName := s.currentCluster
+	row, _ := s.serviceTable.GetSelection()
+	if row <= 0 || row-1 >= len(s.bucketInfos) {
+		return clusterName, nil
+	}
+	return clusterName, s.bucketInfos[row-1]
+}
+
+func (s *uiState) reloadBucketObjects(ctx context.Context) {
+	clusterName, bucket := s.currentBucketSelection()
+	if clusterName == "" || bucket == nil {
+		s.setStatus("[yellow]Select a bucket to reload objects")
+		return
+	}
+	s.setCurrentBucketObjectsKey(makeBucketObjectsKey(clusterName, bucket.Name))
+	s.showBucketObjectsLoading(bucket.Name)
+	go s.fetchBucketObjects(ctx, clusterName, bucket.Name, &bucketObjectRequest{})
+}
+
+func (s *uiState) nextBucketObjectsPage(ctx context.Context) {
+	clusterName, bucket := s.currentBucketSelection()
+	if clusterName == "" || bucket == nil {
+		s.setStatus("[yellow]Select a bucket to load more objects")
+		return
+	}
+	key := makeBucketObjectsKey(clusterName, bucket.Name)
+	s.mutex.Lock()
+	state := s.bucketObjects[key]
+	s.mutex.Unlock()
+	if state == nil || state.NextPage == "" {
+		s.setStatus(fmt.Sprintf("[yellow]No additional objects for %s", bucket.Name))
+		return
+	}
+	prevTokens := append([]string(nil), state.PrevTokens...)
+	prevTokens = append(prevTokens, state.CurrentToken)
+	s.setCurrentBucketObjectsKey(key)
+	s.showBucketObjectsLoading(bucket.Name)
+	go s.fetchBucketObjects(ctx, clusterName, bucket.Name, &bucketObjectRequest{
+		Token:      state.NextPage,
+		PrevTokens: prevTokens,
+	})
+}
+
+func (s *uiState) previousBucketObjectsPage(ctx context.Context) {
+	clusterName, bucket := s.currentBucketSelection()
+	if clusterName == "" || bucket == nil {
+		s.setStatus("[yellow]Select a bucket to load previous objects")
+		return
+	}
+	key := makeBucketObjectsKey(clusterName, bucket.Name)
+	s.mutex.Lock()
+	state := s.bucketObjects[key]
+	s.mutex.Unlock()
+	if state == nil || len(state.PrevTokens) == 0 {
+		s.setStatus(fmt.Sprintf("[yellow]%s is already at the first page", bucket.Name))
+		return
+	}
+	prevTokens := append([]string(nil), state.PrevTokens...)
+	token := prevTokens[len(prevTokens)-1]
+	prevTokens = prevTokens[:len(prevTokens)-1]
+	s.setCurrentBucketObjectsKey(key)
+	s.showBucketObjectsLoading(bucket.Name)
+	go s.fetchBucketObjects(ctx, clusterName, bucket.Name, &bucketObjectRequest{
+		Token:      token,
+		PrevTokens: prevTokens,
+	})
+}
+
+func (s *uiState) loadAllBucketObjects(ctx context.Context) {
+	clusterName, bucket := s.currentBucketSelection()
+	if clusterName == "" || bucket == nil {
+		s.setStatus("[yellow]Select a bucket to load all objects")
+		return
+	}
+	s.setCurrentBucketObjectsKey(makeBucketObjectsKey(clusterName, bucket.Name))
+	s.showBucketObjectsLoading(bucket.Name)
+	go s.fetchBucketObjects(ctx, clusterName, bucket.Name, &bucketObjectRequest{
+		Token: "",
+		Auto:  true,
+	})
+}
+
+func (s *uiState) fetchBucketObjects(ctx context.Context, clusterName, bucketName string, req *bucketObjectRequest) {
+	if req == nil {
+		req = &bucketObjectRequest{}
+	}
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		s.showBucketObjectsError(bucketName)
+		return
+	}
+
+	opts := &storage.BucketListOptions{
+		PageToken:    strings.TrimSpace(req.Token),
+		AutoPaginate: req.Auto,
+	}
+	key := makeBucketObjectsKey(clusterName, bucketName)
+
+	s.mutex.Lock()
+	if s.bucketObjectsCancel != nil {
+		s.bucketObjectsCancel()
+	}
+	s.bucketObjectsSeq++
+	seq := s.bucketObjectsSeq
+	ctxFetch, cancel := context.WithTimeout(ctx, 20*time.Second)
+	s.bucketObjectsCancel = cancel
+	s.mutex.Unlock()
+
+	result, err := storage.ListBucketObjectsWithOptionsContext(ctxFetch, clusterCfg, bucketName, opts)
+	cancel()
+
+	if err != nil {
+		s.mutex.Lock()
+		if seq == s.bucketObjectsSeq {
+			s.bucketObjectsCancel = nil
+		}
+		activeKey := s.currentBucketObjectsKey
+		s.mutex.Unlock()
+		s.setStatus(fmt.Sprintf("[red]Unable to load objects for %s: %v", bucketName, err))
+		if activeKey == key {
+			s.showBucketObjectsError(bucketName)
+		}
+		return
+	}
+
+	if result == nil {
+		result = &storage.BucketListResult{}
+	}
+	state := &bucketObjectState{
+		Objects:       append([]*storage.BucketObject(nil), result.Objects...),
+		NextPage:      result.NextPage,
+		PrevTokens:    append([]string(nil), req.PrevTokens...),
+		CurrentToken:  opts.PageToken,
+		IsTruncated:   result.IsTruncated,
+		Auto:          opts.AutoPaginate,
+		ReturnedItems: result.ReturnedItems,
+	}
+	if state.Objects == nil {
+		state.Objects = []*storage.BucketObject{}
+	}
+
+	s.mutex.Lock()
+	if seq != s.bucketObjectsSeq {
+		s.mutex.Unlock()
+		return
+	}
+	s.bucketObjectsCancel = nil
+	s.bucketObjects[key] = state
+	activeKey := s.currentBucketObjectsKey
+	s.mutex.Unlock()
+
+	if activeKey == key {
+		s.renderBucketObjects(bucketName, state)
+		s.updateBucketObjectsStatus(bucketName, state)
+	}
+}

--- a/pkg/tui/buckets_view.go
+++ b/pkg/tui/buckets_view.go
@@ -1,0 +1,249 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rivo/tview"
+
+	"github.com/grycap/oscar-cli/pkg/storage"
+)
+
+func (s *uiState) switchToBuckets(ctx context.Context) {
+	if s.searchVisible {
+		s.hideSearch()
+	}
+	s.mutex.Lock()
+	if s.confirmVisible || s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	if s.mode == modeBuckets {
+		s.mutex.Unlock()
+		return
+	}
+	s.mode = modeBuckets
+	if s.loadCancel != nil {
+		s.loadCancel()
+		s.loadCancel = nil
+		s.refreshing = false
+		s.loadingCluster = ""
+	}
+	if s.detailTimer != nil {
+		s.detailTimer.Stop()
+		s.detailTimer = nil
+	}
+	s.lastSelection = ""
+	s.currentBucketObjectsKey = ""
+	s.mutex.Unlock()
+
+	clusterName := s.currentCluster
+	if clusterName == "" {
+		s.setStatus("[red]Select a cluster to view buckets")
+		s.queueUpdate(func() {
+			s.showBucketMessage("Select a cluster to view buckets")
+		})
+		s.showBucketObjectsPrompt("Select a bucket to list objects")
+		s.showClusterDetails(clusterName)
+		return
+	}
+
+	s.showClusterDetails(clusterName)
+	s.queueUpdate(func() {
+		s.showBucketMessage("Loading buckets…")
+	})
+	s.showBucketObjectsPrompt("Select a bucket to list objects")
+
+	s.mutex.Lock()
+	cached := s.bucketInfos
+	cachedCluster := s.bucketCluster
+	s.mutex.Unlock()
+	if len(cached) > 0 && cachedCluster == clusterName {
+		s.renderBucketTable(cached)
+		s.setStatus(fmt.Sprintf("[green]Loaded %d bucket(s) for %s", len(cached), clusterName))
+		return
+	}
+
+	go s.loadBuckets(ctx, clusterName, false)
+}
+
+func (s *uiState) loadBuckets(ctx context.Context, name string, force bool) {
+	if name == "" {
+		return
+	}
+
+	clusterCfg := s.conf.Oscar[name]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", name))
+		s.queueUpdate(func() {
+			s.showBucketMessage("Cluster not found")
+		})
+		return
+	}
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading buckets for cluster %s…", name))
+	s.queueUpdate(func() {
+		s.showBucketMessage("Loading buckets…")
+	})
+
+	s.mutex.Lock()
+	if s.bucketCancel != nil {
+		s.bucketCancel()
+		s.bucketCancel = nil
+	}
+	s.bucketSeq++
+	seq := s.bucketSeq
+	ctxFetch, cancel := context.WithTimeout(ctx, 15*time.Second)
+	s.bucketCancel = cancel
+	s.mutex.Unlock()
+
+	buckets, err := storage.ListBucketsWithContext(ctxFetch, clusterCfg)
+	cancel()
+	if err != nil {
+		s.setStatus(fmt.Sprintf("[red]Unable to load buckets for %s: %v", name, err))
+		s.mutex.Lock()
+		if seq == s.bucketSeq {
+			s.bucketInfos = nil
+			s.bucketCancel = nil
+			s.bucketCluster = ""
+		}
+		s.mutex.Unlock()
+		s.queueUpdate(func() {
+			s.showBucketMessage("Unable to load buckets")
+		})
+		return
+	}
+
+	s.mutex.Lock()
+	if seq != s.bucketSeq {
+		s.mutex.Unlock()
+		return
+	}
+	s.bucketInfos = buckets
+	s.bucketCancel = nil
+	s.bucketCluster = name
+	mode := s.mode
+	currentCluster := s.currentCluster
+	s.mutex.Unlock()
+
+	if mode == modeBuckets && currentCluster == name {
+		s.renderBucketTable(buckets)
+		s.setStatus(fmt.Sprintf("[green]Loaded %d bucket(s) for %s", len(buckets), name))
+	}
+}
+
+func (s *uiState) handleBucketSelection(row int, immediate bool) {
+	s.mutex.Lock()
+	if s.mode != modeBuckets {
+		s.mutex.Unlock()
+		return
+	}
+	clusterName := s.currentCluster
+	var bucket *storage.BucketInfo
+	if row > 0 && row-1 < len(s.bucketInfos) {
+		bucket = s.bucketInfos[row-1]
+	}
+	s.mutex.Unlock()
+
+	if bucket == nil {
+		s.queueUpdate(func() {
+			s.detailsView.SetText("Select a bucket to inspect details")
+		})
+		s.setCurrentBucketObjectsKey("")
+		s.showBucketObjectsPrompt("Select a bucket to list objects")
+		return
+	}
+
+	s.queueUpdate(func() {
+		s.detailsView.SetText(formatBucketDetails(bucket))
+	})
+	s.setCurrentBucketObjectsKey(makeBucketObjectsKey(clusterName, bucket.Name))
+	s.presentBucketObjects(clusterName, bucket.Name)
+	if immediate {
+		s.focusBucketObjectsTable()
+	}
+}
+
+func (s *uiState) renderBucketTable(buckets []*storage.BucketInfo) {
+	s.queueUpdate(func() {
+		s.serviceTable.SetTitle("Buckets")
+		setBucketTableHeader(s.serviceTable)
+		if len(buckets) == 0 {
+			fillMessageRow(s.serviceTable, len(bucketHeaders), "No buckets found")
+			s.detailsView.SetText("Select a bucket to inspect details")
+			s.showBucketObjectsPrompt("Select a bucket to list objects")
+			return
+		}
+		for i, bucket := range buckets {
+			row := i + 1
+			color := bucketVisibilityColor(bucket.Visibility)
+			nameCell := tview.NewTableCell(bucket.Name).
+				SetSelectable(true).
+				SetExpansion(4)
+			visCell := tview.NewTableCell(defaultIfEmpty(bucket.Visibility, "-")).
+				SetExpansion(2).
+				SetTextColor(color)
+			ownerCell := tview.NewTableCell(defaultIfEmpty(bucket.Owner, "-")).
+				SetExpansion(5)
+			s.serviceTable.SetCell(row, 0, nameCell).
+				SetCell(row, 1, visCell).
+				SetCell(row, 2, ownerCell)
+		}
+		row, col := s.serviceTable.GetSelection()
+		if row <= 0 || row > len(buckets) {
+			s.serviceTable.Select(1, 0)
+		} else {
+			s.serviceTable.Select(row, col)
+		}
+	})
+}
+
+func (s *uiState) showBucketMessage(message string) {
+	s.serviceTable.SetTitle("Buckets")
+	setBucketTableHeader(s.serviceTable)
+	fillMessageRow(s.serviceTable, len(bucketHeaders), message)
+}
+
+func (s *uiState) performBucketDeletion(clusterName, bucketName string) {
+	s.setStatus(fmt.Sprintf("[yellow]Deleting bucket %q...", bucketName))
+	s.mutex.Lock()
+	s.lastSelection = ""
+	s.mutex.Unlock()
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+	if err := storage.DeleteBucket(clusterCfg, bucketName); err != nil {
+		s.setStatus(fmt.Sprintf("[red]Failed to delete bucket %q: %v", bucketName, err))
+		return
+	}
+	s.setStatus(fmt.Sprintf("[green]Bucket %q deleted", bucketName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText("Select a bucket to inspect details")
+	})
+	s.refreshCurrent(context.Background())
+}
+
+func (s *uiState) searchBuckets(query string) bool {
+	s.mutex.Lock()
+	buckets := append([]*storage.BucketInfo(nil), s.bucketInfos...)
+	s.mutex.Unlock()
+	for idx, bucket := range buckets {
+		if bucket == nil {
+			continue
+		}
+		haystack := strings.ToLower(bucket.Name + " " + bucket.Owner + " " + bucket.Visibility)
+		if strings.Contains(haystack, query) {
+			row := idx + 1
+			s.queueUpdate(func() {
+				s.serviceTable.Select(row, 0)
+				s.handleBucketSelection(row, false)
+			})
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tui/dialogs.go
+++ b/pkg/tui/dialogs.go
@@ -1,0 +1,172 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rivo/tview"
+)
+
+func (s *uiState) toggleLegend() {
+	s.mutex.Lock()
+	visible := s.legendVisible
+	confirm := s.confirmVisible
+	s.mutex.Unlock()
+	if visible {
+		s.queueUpdate(func() {
+			s.hideLegendUnlocked()
+		})
+		return
+	}
+	if confirm || s.pages == nil {
+		return
+	}
+	s.queueUpdate(func() {
+		s.showLegendUnlocked()
+	})
+}
+
+func (s *uiState) showLegendUnlocked() {
+	if s.pages == nil {
+		return
+	}
+	s.mutex.Lock()
+	if s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.legendVisible = true
+	s.savedFocus = s.app.GetFocus()
+	s.mutex.Unlock()
+	modal := tview.NewModal().
+		SetText(legendText).
+		AddButtons([]string{"Close"})
+	modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+		s.hideLegendUnlocked()
+	})
+	s.pages.AddAndSwitchToPage("legend", modal, true)
+}
+
+func (s *uiState) hideLegendUnlocked() {
+	if s.pages == nil {
+		return
+	}
+	s.mutex.Lock()
+	if !s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.legendVisible = false
+	focus := s.savedFocus
+	s.savedFocus = nil
+	s.mutex.Unlock()
+	s.pages.RemovePage("legend")
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
+}
+
+func (s *uiState) requestDeletion() {
+	s.mutex.Lock()
+	mode := s.mode
+	if s.confirmVisible || s.legendVisible || s.pages == nil {
+		s.mutex.Unlock()
+		return
+	}
+	row, _ := s.serviceTable.GetSelection()
+	clusterName := s.currentCluster
+	switch mode {
+	case modeServices:
+		if row <= 0 || row-1 >= len(s.currentServices) || clusterName == "" {
+			s.mutex.Unlock()
+			s.setStatus("[red]Select a service to delete")
+			return
+		}
+		svcPtr := s.currentServices[row-1]
+		if svcPtr == nil {
+			s.mutex.Unlock()
+			s.setStatus("[red]Select a service to delete")
+			return
+		}
+		if s.detailTimer != nil {
+			s.detailTimer.Stop()
+			s.detailTimer = nil
+		}
+		svcName := svcPtr.Name
+		s.mutex.Unlock()
+
+		prompt := fmt.Sprintf("Delete service %q from cluster %q?", svcName, clusterName)
+		s.queueUpdate(func() {
+			s.showConfirmation(prompt, func() {
+				go s.performDeletion(clusterName, svcName)
+			})
+		})
+	case modeBuckets:
+		if row <= 0 || row-1 >= len(s.bucketInfos) || clusterName == "" {
+			s.mutex.Unlock()
+			s.setStatus("[red]Select a bucket to delete")
+			return
+		}
+		bucket := s.bucketInfos[row-1]
+		if bucket == nil || strings.TrimSpace(bucket.Name) == "" {
+			s.mutex.Unlock()
+			s.setStatus("[red]Select a bucket to delete")
+			return
+		}
+		bucketName := bucket.Name
+		s.mutex.Unlock()
+
+		prompt := fmt.Sprintf("Delete bucket %q from cluster %q?", bucketName, clusterName)
+		s.queueUpdate(func() {
+			s.showConfirmation(prompt, func() {
+				go s.performBucketDeletion(clusterName, bucketName)
+			})
+		})
+	default:
+		s.mutex.Unlock()
+		s.setStatus("[red]Deletion not available in this view")
+	}
+}
+
+func (s *uiState) showConfirmation(text string, onConfirm func()) {
+	if s.pages == nil {
+		return
+	}
+	s.mutex.Lock()
+	if s.confirmVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.confirmVisible = true
+	s.savedFocus = s.app.GetFocus()
+	s.mutex.Unlock()
+	modal := tview.NewModal().
+		SetText(text).
+		AddButtons([]string{"Cancel", "Delete"})
+	modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+		if buttonLabel == "Delete" {
+			onConfirm()
+		}
+		s.hideConfirmationUnlocked()
+	})
+	s.pages.AddAndSwitchToPage("confirm", modal, true)
+}
+
+func (s *uiState) hideConfirmationUnlocked() {
+	if s.pages == nil {
+		return
+	}
+	s.mutex.Lock()
+	if !s.confirmVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.confirmVisible = false
+	focus := s.savedFocus
+	s.savedFocus = nil
+	s.mutex.Unlock()
+	s.pages.RemovePage("confirm")
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
+}

--- a/pkg/tui/formatters.go
+++ b/pkg/tui/formatters.go
@@ -1,0 +1,183 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rivo/tview"
+
+	"github.com/grycap/oscar-cli/pkg/cluster"
+	"github.com/grycap/oscar-cli/pkg/storage"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+func truncateString(val string, limit int) string {
+	if limit <= 0 || len(val) <= limit {
+		return val
+	}
+	return val[:limit-1] + "…"
+}
+
+func defaultIfEmpty(val, fallback string) string {
+	if strings.TrimSpace(val) == "" {
+		return fallback
+	}
+	return val
+}
+
+func formatClusterInfo(clusterName string, info types.Info) string {
+	builder := &strings.Builder{}
+	if clusterName != "" {
+		fmt.Fprintf(builder, "[yellow]Cluster:[-] %s\n", clusterName)
+	}
+	if info.Version != "" {
+		fmt.Fprintf(builder, "[yellow]Version:[-] %s\n", info.Version)
+	}
+	if info.GitCommit != "" {
+		fmt.Fprintf(builder, "[yellow]Commit:[-] %s\n", info.GitCommit)
+	}
+	if info.Architecture != "" {
+		fmt.Fprintf(builder, "[yellow]Architecture:[-] %s\n", info.Architecture)
+	}
+	if info.KubeVersion != "" {
+		fmt.Fprintf(builder, "[yellow]Kubernetes:[-] %s\n", info.KubeVersion)
+	}
+	if backend := info.ServerlessBackendInfo; backend != nil {
+		if backend.Name != "" {
+			fmt.Fprintf(builder, "[yellow]Serverless:[-] %s", backend.Name)
+			if backend.Version != "" {
+				fmt.Fprintf(builder, " %s", backend.Version)
+			}
+			builder.WriteByte('\n')
+		} else if backend.Version != "" {
+			fmt.Fprintf(builder, "[yellow]Serverless:[-] %s\n", backend.Version)
+		}
+	}
+	out := strings.TrimRight(builder.String(), "\n")
+	if out == "" {
+		return "No cluster information available"
+	}
+	return out
+}
+
+func formatServiceLogs(serviceName, jobName, logs string) string {
+	builder := &strings.Builder{}
+	if serviceName != "" {
+		fmt.Fprintf(builder, "[yellow]Service:[-] %s\n", serviceName)
+	}
+	if jobName != "" {
+		fmt.Fprintf(builder, "[yellow]Job:[-] %s\n", jobName)
+	}
+	clean := strings.TrimSpace(logs)
+	if clean == "" {
+		builder.WriteString("No logs available")
+		return builder.String()
+	}
+	builder.WriteString("\n")
+	builder.WriteString(tview.Escape(clean))
+	return builder.String()
+}
+
+func formatClusterConfig(name string, cfg *cluster.Cluster) string {
+	title := strings.TrimSpace(name)
+	if title == "" {
+		title = "Cluster"
+	}
+	if cfg == nil {
+		return fmt.Sprintf("[yellow]%s:[-]\n    configuration not available", title)
+	}
+
+	builder := &strings.Builder{}
+	fmt.Fprintf(builder, "[yellow]%s:[-]\n", title)
+	appendField := func(label, value string) {
+		if strings.TrimSpace(value) == "" {
+			return
+		}
+		fmt.Fprintf(builder, "    %s: %s\n", label, value)
+	}
+
+	appendField("endpoint", cfg.Endpoint)
+	appendField("auth_user", cfg.AuthUser)
+	if cfg.AuthPassword != "" {
+		appendField("auth_password", maskSecret(cfg.AuthPassword))
+	}
+	appendField("oidc_account_name", cfg.OIDCAccountName)
+	if cfg.OIDCRefreshToken != "" {
+		appendField("oidc_refresh_token", trimToken(cfg.OIDCRefreshToken))
+	}
+	appendField("ssl_verify", strconv.FormatBool(cfg.SSLVerify))
+	appendField("memory", strings.TrimSpace(cfg.Memory))
+	appendField("log_level", strings.TrimSpace(cfg.LogLevel))
+
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func maskSecret(secret string) string {
+	if secret == "" {
+		return ""
+	}
+	const maxStars = 8
+	if len(secret) <= maxStars {
+		return strings.Repeat("*", len(secret))
+	}
+	return strings.Repeat("*", maxStars)
+}
+
+func trimToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	firstLine := strings.Split(token, "\n")[0]
+	const limit = 64
+	if len(firstLine) > limit {
+		return firstLine[:limit]
+	}
+	return firstLine
+}
+
+func formatServiceDetails(svc *types.Service) string {
+	if svc == nil {
+		return ""
+	}
+	builder := &strings.Builder{}
+	fmt.Fprintf(builder, "[yellow]Name:[-] %s\n", svc.Name)
+	if svc.ClusterID != "" {
+		fmt.Fprintf(builder, "[yellow]Cluster:[-] %s\n", svc.ClusterID)
+	}
+	if svc.Image != "" {
+		fmt.Fprintf(builder, "[yellow]Image:[-] %s\n", svc.Image)
+	}
+	if svc.Memory != "" {
+		fmt.Fprintf(builder, "[yellow]Memory:[-] %s\n", svc.Memory)
+	}
+	if svc.CPU != "" {
+		fmt.Fprintf(builder, "[yellow]CPU:[-] %s\n", svc.CPU)
+	}
+	if replicas := len(svc.Replicas); replicas > 0 {
+		fmt.Fprintf(builder, "[yellow]Replicas:[-] %d\n", replicas)
+	}
+	if svc.LogLevel != "" {
+		fmt.Fprintf(builder, "[yellow]Log Level:[-] %s\n", svc.LogLevel)
+	}
+	return builder.String()
+}
+
+func formatBucketDetails(bucket *storage.BucketInfo) string {
+	if bucket == nil {
+		return ""
+	}
+	builder := &strings.Builder{}
+	fmt.Fprintf(builder, "[yellow]Name:[-] %s\n", bucket.Name)
+	if bucket.Visibility != "" {
+		fmt.Fprintf(builder, "[yellow]Visibility:[-] %s\n", bucket.Visibility)
+	}
+	if len(bucket.AllowedUsers) > 0 {
+		fmt.Fprintf(builder, "[yellow]Allowed Users:[-] %s\n", strings.Join(bucket.AllowedUsers, ", "))
+	}
+	if bucket.Owner != "" {
+		fmt.Fprintf(builder, "[yellow]Owner:[-] %s\n", bucket.Owner)
+	}
+
+	return builder.String()
+}

--- a/pkg/tui/helpers_test.go
+++ b/pkg/tui/helpers_test.go
@@ -1,0 +1,82 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+func TestDefaultIfEmpty(t *testing.T) {
+	if got := defaultIfEmpty(" value ", "fallback"); got != " value " {
+		t.Fatalf("expected original value, got %q", got)
+	}
+	if got := defaultIfEmpty("   ", "fallback"); got != "fallback" {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+}
+
+func TestMaskSecret(t *testing.T) {
+	if got := maskSecret(""); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+	if got := maskSecret("secret"); got != "******" {
+		t.Fatalf("expected masked secret, got %q", got)
+	}
+	long := strings.Repeat("x", 32)
+	if got := maskSecret(long); got != strings.Repeat("*", 8) {
+		t.Fatalf("expected capped mask, got %q", got)
+	}
+}
+
+func TestTrimToken(t *testing.T) {
+	token := strings.Repeat("a", 70) + "\nsecond line"
+	got := trimToken(token)
+	if len(got) != 64 {
+		t.Fatalf("expected trimmed token length 64, got %d", len(got))
+	}
+	if strings.Contains(got, "\n") {
+		t.Fatalf("expected first line only, got %q", got)
+	}
+}
+
+func TestBucketVisibilityColor(t *testing.T) {
+	tests := []struct {
+		value string
+		color tcell.Color
+	}{
+		{"restricted", tcell.ColorYellow},
+		{"private", tcell.ColorRed},
+		{"public", tcell.ColorGreen},
+		{"", tcell.ColorWhite},
+	}
+	for _, tt := range tests {
+		if got := bucketVisibilityColor(tt.value); got != tt.color {
+			t.Fatalf("bucketVisibilityColor(%q) = %v, want %v", tt.value, got, tt.color)
+		}
+	}
+}
+
+func TestFormatServiceDefinition(t *testing.T) {
+	svc := &types.Service{
+		Name:     "demo",
+		Image:    "demo:v1",
+		Memory:   "128Mi",
+		Replicas: []types.Replica{{Type: "oscar", ServiceName: "demo"}},
+	}
+
+	rendered, err := formatServiceDefinition(svc)
+	if err != nil {
+		t.Fatalf("formatServiceDefinition returned error: %v", err)
+	}
+	if rendered == "" {
+		t.Fatal("expected formatted definition")
+	}
+	if !strings.Contains(rendered, "[yellow]name") {
+		t.Fatalf("expected colored key in output, got %q", rendered)
+	}
+	if !strings.Contains(rendered, "[green]\"demo\"") {
+		t.Fatalf("expected colored value in output, got %q", rendered)
+	}
+}

--- a/pkg/tui/logs_view.go
+++ b/pkg/tui/logs_view.go
@@ -1,0 +1,424 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rivo/tview"
+
+	"github.com/grycap/oscar-cli/pkg/service"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+type logEntry struct {
+	Name string
+	Info *types.JobInfo
+}
+
+func (s *uiState) switchToLogs(ctx context.Context) {
+	if s.searchVisible {
+		s.hideSearch()
+	}
+
+	s.mutex.Lock()
+	if s.confirmVisible || s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	if s.mode == modeBuckets {
+		s.mutex.Unlock()
+		s.setStatus("[red]Logs are only available in services view")
+		return
+	}
+
+	row, _ := s.serviceTable.GetSelection()
+	if row <= 0 || row-1 >= len(s.currentServices) {
+		s.mutex.Unlock()
+		s.setStatus("[red]Select a service to view logs")
+		return
+	}
+	svcPtr := s.currentServices[row-1]
+	clusterName := s.currentCluster
+	if s.detailTimer != nil {
+		s.detailTimer.Stop()
+		s.detailTimer = nil
+	}
+	s.lastSelection = ""
+	s.mutex.Unlock()
+
+	if svcPtr == nil {
+		s.setStatus("[red]Select a service to view logs")
+		return
+	}
+	serviceName := strings.TrimSpace(svcPtr.Name)
+	if serviceName == "" {
+		s.setStatus("[red]Select a service to view logs")
+		return
+	}
+
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" {
+		s.setStatus("[red]Select a cluster to view logs")
+		return
+	}
+
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+
+	key := makeLogKey(clusterName, serviceName)
+	s.mutex.Lock()
+	s.mode = modeLogs
+	s.currentLogsKey = key
+	s.currentLogService = serviceName
+	s.currentLogCluster = clusterName
+	s.logEntries = nil
+	s.currentLogJobKey = ""
+	s.mutex.Unlock()
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading logs for %q…", serviceName))
+	s.queueUpdate(func() {
+		s.showLogMessage(serviceName, "Loading logs…")
+		s.detailsView.SetText("Select a log entry to view contents")
+	})
+
+	parent := ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	go s.loadLogs(parent, clusterName, serviceName, false)
+}
+
+func (s *uiState) loadLogs(ctx context.Context, clusterName, serviceName string, force bool) {
+	if strings.TrimSpace(clusterName) == "" || strings.TrimSpace(serviceName) == "" {
+		return
+	}
+
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		s.queueUpdate(func() {
+			s.showLogMessage(serviceName, "Cluster not found")
+		})
+		return
+	}
+
+	key := makeLogKey(clusterName, serviceName)
+
+	s.mutex.Lock()
+	cachedKey := s.currentLogsKey
+	cachedEntries := append([]*logEntry(nil), s.logEntries...)
+	if !force && cachedKey == key && len(cachedEntries) > 0 {
+		s.mutex.Unlock()
+		if s.modeIsLogs() {
+			s.renderLogTable(cachedEntries, serviceName)
+		}
+		return
+	}
+	s.logSeq++
+	seq := s.logSeq
+	s.currentLogsKey = key
+	s.currentLogService = serviceName
+	s.currentLogCluster = clusterName
+	s.logEntries = nil
+	s.mutex.Unlock()
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading logs for %q…", serviceName))
+	s.queueUpdate(func() {
+		s.showLogMessage(serviceName, "Loading logs…")
+	})
+
+	page := ""
+	entries := map[string]*types.JobInfo{}
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.setStatus("[red]Log loading cancelled")
+			return
+		default:
+		}
+
+		resp, err := service.ListLogs(clusterCfg, serviceName, page)
+		if err != nil {
+			s.setStatus(fmt.Sprintf("[red]Unable to load logs for %q: %v", serviceName, err))
+			s.queueUpdate(func() {
+				s.showLogMessage(serviceName, "Unable to load logs")
+			})
+			return
+		}
+
+		for name, info := range resp.Jobs {
+			entries[name] = info
+		}
+
+		if strings.TrimSpace(resp.NextPage) == "" {
+			break
+		}
+		page = resp.NextPage
+	}
+
+	list := make([]*logEntry, 0, len(entries))
+	for name, info := range entries {
+		list = append(list, &logEntry{
+			Name: name,
+			Info: info,
+		})
+	}
+
+	sort.Slice(list, func(i, j int) bool {
+		ti := jobTimestamp(list[i].Info)
+		tj := jobTimestamp(list[j].Info)
+		switch {
+		case ti.IsZero() && tj.IsZero():
+			return list[i].Name > list[j].Name
+		case ti.IsZero():
+			return false
+		case tj.IsZero():
+			return true
+		case ti.Equal(tj):
+			return list[i].Name > list[j].Name
+		default:
+			return ti.After(tj)
+		}
+	})
+
+	s.mutex.Lock()
+	if seq != s.logSeq || s.currentLogsKey != key {
+		s.mutex.Unlock()
+		return
+	}
+	s.logEntries = list
+	mode := s.mode
+	currentCluster := s.currentCluster
+	currentService := s.currentLogService
+	s.mutex.Unlock()
+
+	if mode == modeLogs && currentCluster == clusterName && currentService == serviceName {
+		s.renderLogTable(list, serviceName)
+		s.setStatus(fmt.Sprintf("[green]Loaded %d log(s) for %q", len(list), serviceName))
+	}
+}
+
+func (s *uiState) renderLogTable(entries []*logEntry, serviceName string) {
+	s.queueUpdate(func() {
+		s.serviceTable.SetTitle(fmt.Sprintf("Logs: %s", serviceName))
+		setLogTableHeader(s.serviceTable)
+		if len(entries) == 0 {
+			fillMessageRow(s.serviceTable, len(logHeaders), "No logs found")
+			s.detailsView.SetText("No logs available")
+			return
+		}
+		for idx, entry := range entries {
+			row := idx + 1
+			status := "-"
+			started := "-"
+			finished := "-"
+			if entry.Info != nil {
+				status = defaultIfEmpty(entry.Info.Status, "-")
+				started = formatLogTime(jobStartTime(entry.Info))
+				finished = formatLogTime(jobFinishTime(entry.Info))
+			}
+			s.serviceTable.SetCell(row, 0, tview.NewTableCell(entry.Name).
+				SetSelectable(true).
+				SetExpansion(4)).
+				SetCell(row, 1, tview.NewTableCell(status).
+					SetExpansion(2)).
+				SetCell(row, 2, tview.NewTableCell(started).
+					SetExpansion(3)).
+				SetCell(row, 3, tview.NewTableCell(finished).
+					SetExpansion(3))
+		}
+		row, col := s.serviceTable.GetSelection()
+		if row <= 0 || row > len(entries) {
+			s.serviceTable.Select(1, 0)
+		} else {
+			s.serviceTable.Select(row, col)
+		}
+	})
+}
+
+func (s *uiState) showLogMessage(serviceName, message string) {
+	s.serviceTable.SetTitle(fmt.Sprintf("Logs: %s", serviceName))
+	setLogTableHeader(s.serviceTable)
+	fillMessageRow(s.serviceTable, len(logHeaders), message)
+}
+
+func (s *uiState) handleLogSelection(row int, immediate bool) {
+	s.mutex.Lock()
+	if s.mode != modeLogs {
+		if s.detailTimer != nil {
+			s.detailTimer.Stop()
+			s.detailTimer = nil
+		}
+		s.mutex.Unlock()
+		return
+	}
+	entries := append([]*logEntry(nil), s.logEntries...)
+	clusterName := s.currentLogCluster
+	serviceName := s.currentLogService
+	seq := s.logSeq
+	if row <= 0 || row-1 >= len(entries) {
+		if s.detailTimer != nil {
+			s.detailTimer.Stop()
+			s.detailTimer = nil
+		}
+		s.lastSelection = ""
+		s.mutex.Unlock()
+		s.queueUpdate(func() {
+			s.detailsView.SetText("Select a log entry to view contents")
+		})
+		return
+	}
+	entry := entries[row-1]
+	token := fmt.Sprintf("log:%s:%d:%d", entry.Name, row, seq)
+	if s.detailTimer != nil {
+		s.detailTimer.Stop()
+		s.detailTimer = nil
+	}
+	s.lastSelection = token
+	s.mutex.Unlock()
+
+	if immediate {
+		s.showLogDetails(clusterName, serviceName, entry.Name)
+		return
+	}
+
+	timer := time.AfterFunc(500*time.Millisecond, func() {
+		s.mutex.Lock()
+		if s.lastSelection != token {
+			s.mutex.Unlock()
+			return
+		}
+		s.detailTimer = nil
+		s.mutex.Unlock()
+		s.showLogDetails(clusterName, serviceName, entry.Name)
+	})
+
+	s.mutex.Lock()
+	if s.lastSelection == token {
+		s.detailTimer = timer
+	} else {
+		timer.Stop()
+	}
+	s.mutex.Unlock()
+}
+
+func (s *uiState) showLogDetails(clusterName, serviceName, jobName string) {
+	clusterName = strings.TrimSpace(clusterName)
+	serviceName = strings.TrimSpace(serviceName)
+	jobName = strings.TrimSpace(jobName)
+	if clusterName == "" || serviceName == "" || jobName == "" {
+		s.queueUpdate(func() {
+			s.detailsView.SetText("Select a log entry to view contents")
+		})
+		return
+	}
+
+	key := makeLogDetailKey(clusterName, serviceName, jobName)
+	s.mutex.Lock()
+	cached := s.logDetails[key]
+	s.logDetailSeq++
+	seq := s.logDetailSeq
+	s.currentLogJobKey = key
+	s.mutex.Unlock()
+
+	if cached != "" {
+		s.queueUpdate(func() {
+			s.detailsView.SetText(cached)
+		})
+		return
+	}
+
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("Loading log %s…", jobName))
+	})
+	s.setStatus(fmt.Sprintf("[yellow]Loading log %q…", jobName))
+
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+
+	go func(seq int, key string) {
+		logText, err := service.GetLogs(clusterCfg, serviceName, jobName, false)
+		if err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to load log %q: %v", jobName, err))
+			return
+		}
+
+		rendered := formatServiceLogs(serviceName, jobName, logText)
+		s.mutex.Lock()
+		if seq != s.logDetailSeq {
+			s.mutex.Unlock()
+			return
+		}
+		s.logDetails[key] = rendered
+		active := s.currentLogJobKey == key
+		s.mutex.Unlock()
+
+		if active {
+			s.queueUpdate(func() {
+				s.detailsView.SetText(rendered)
+			})
+			s.setStatus(fmt.Sprintf("[green]Loaded log %q", jobName))
+		}
+	}(seq, key)
+}
+
+func jobTimestamp(info *types.JobInfo) time.Time {
+	if info == nil {
+		return time.Time{}
+	}
+	if info.CreationTime != nil {
+		return info.CreationTime.Time
+	}
+	if info.StartTime != nil {
+		return info.StartTime.Time
+	}
+	if info.FinishTime != nil {
+		return info.FinishTime.Time
+	}
+	return time.Time{}
+}
+
+func jobStartTime(info *types.JobInfo) time.Time {
+	if info == nil {
+		return time.Time{}
+	}
+	if info.StartTime != nil {
+		return info.StartTime.Time
+	}
+	if info.CreationTime != nil {
+		return info.CreationTime.Time
+	}
+	return time.Time{}
+}
+
+func jobFinishTime(info *types.JobInfo) time.Time {
+	if info == nil || info.FinishTime == nil {
+		return time.Time{}
+	}
+	return info.FinishTime.Time
+}
+
+func formatLogTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Local().Format("2006-01-02 15:04:05")
+}
+
+func makeLogKey(clusterName, serviceName string) string {
+	return fmt.Sprintf("%s\x00%s", clusterName, serviceName)
+}
+
+func makeLogDetailKey(clusterName, serviceName, jobName string) string {
+	return fmt.Sprintf("%s\x00%s\x00%s", clusterName, serviceName, jobName)
+}

--- a/pkg/tui/search.go
+++ b/pkg/tui/search.go
@@ -1,0 +1,258 @@
+package tui
+
+import (
+	"context"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func (s *uiState) initiateSearch(ctx context.Context) {
+	_ = ctx
+	s.mutex.Lock()
+	if s.searchVisible || s.confirmVisible || s.legendVisible || s.pages == nil {
+		s.mutex.Unlock()
+		return
+	}
+	focus := s.app.GetFocus()
+	mode := s.mode
+	s.mutex.Unlock()
+
+	target := searchTargetNone
+	switch focus {
+	case s.clusterList:
+		target = searchTargetClusters
+	case s.serviceTable:
+		if mode == modeBuckets {
+			target = searchTargetBuckets
+		} else if mode == modeLogs {
+			target = searchTargetLogs
+		} else {
+			target = searchTargetServices
+		}
+	case s.detailsView:
+		target = searchTargetDetails
+	}
+
+	if target == searchTargetNone && len(s.clusterNames) > 0 {
+		target = searchTargetClusters
+	}
+
+	if target == searchTargetNone {
+		return
+	}
+
+	s.mutex.Lock()
+	switch target {
+	case searchTargetClusters:
+		if len(s.clusterNames) == 0 {
+			s.mutex.Unlock()
+			s.setStatus("[yellow]No clusters to search")
+			return
+		}
+	case searchTargetServices:
+		if len(s.currentServices) == 0 {
+			s.mutex.Unlock()
+			s.setStatus("[yellow]No services to search")
+			return
+		}
+	case searchTargetLogs:
+		if len(s.logEntries) == 0 {
+			s.mutex.Unlock()
+			s.setStatus("[yellow]No logs to search")
+			return
+		}
+	case searchTargetBuckets:
+		if len(s.bucketInfos) == 0 {
+			s.mutex.Unlock()
+			s.setStatus("[yellow]No buckets to search")
+			return
+		}
+	case searchTargetDetails:
+		text := s.detailsView.GetText(true)
+		if strings.TrimSpace(text) == "" {
+			s.mutex.Unlock()
+			s.setStatus("[yellow]Nothing to search in details")
+			return
+		}
+	}
+	s.mutex.Unlock()
+
+	s.showSearch(target)
+}
+
+func (s *uiState) showSearch(target searchTarget) {
+	s.mutex.Lock()
+	if s.searchVisible || s.pages == nil {
+		s.mutex.Unlock()
+		return
+	}
+	s.searchVisible = true
+	s.searchTarget = target
+	s.originalFocus = s.app.GetFocus()
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	label := "Search: "
+	switch target {
+	case searchTargetClusters:
+		label = "Clusters: "
+	case searchTargetServices:
+		label = "Services: "
+	case searchTargetBuckets:
+		label = "Buckets: "
+	case searchTargetDetails:
+		label = "Details: "
+	}
+
+	input := tview.NewInputField().
+		SetLabel(label).
+		SetFieldWidth(30)
+	input.SetChangedFunc(func(text string) {
+		s.handleSearchInput(text)
+	})
+	input.SetDoneFunc(func(key tcell.Key) {
+		s.hideSearch()
+	})
+
+	s.mutex.Lock()
+	s.searchInput = input
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Search")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) hideSearch() {
+	s.mutex.Lock()
+	if !s.searchVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.searchVisible = false
+	s.searchTarget = searchTargetNone
+	input := s.searchInput
+	s.searchInput = nil
+	focus := s.originalFocus
+	s.originalFocus = nil
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Status")
+		container.AddItem(s.statusView, 0, 1, false)
+		s.statusView.SetText(s.decorateStatusText(statusHelpText))
+	})
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
+
+	if input != nil {
+		input.SetText("")
+	}
+}
+
+func (s *uiState) handleSearchInput(query string) {
+	s.mutex.Lock()
+	target := s.searchTarget
+	s.mutex.Unlock()
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" {
+		return
+	}
+	lower := strings.ToLower(trimmed)
+	var found bool
+	switch target {
+	case searchTargetClusters:
+		found = s.searchClusters(lower)
+	case searchTargetServices:
+		found = s.searchServices(lower)
+	case searchTargetLogs:
+		found = s.searchLogs(lower)
+	case searchTargetBuckets:
+		found = s.searchBuckets(lower)
+	case searchTargetDetails:
+		found = s.searchDetails(lower)
+	}
+	if !found {
+		s.setStatus("[yellow]No matches found")
+	}
+}
+
+func (s *uiState) searchClusters(query string) bool {
+	s.mutex.Lock()
+	names := append([]string(nil), s.clusterNames...)
+	s.mutex.Unlock()
+	for idx, name := range names {
+		haystack := name
+		if cfg := s.conf.Oscar[name]; cfg != nil {
+			haystack = strings.Join([]string{
+				name,
+				cfg.Endpoint,
+				cfg.AuthUser,
+				cfg.OIDCAccountName,
+			}, " ")
+		}
+		if containsQuery(haystack, query) {
+			s.queueUpdate(func() {
+				s.clusterList.SetCurrentItem(idx)
+			})
+			return true
+		}
+	}
+	return false
+}
+
+func (s *uiState) searchLogs(query string) bool {
+	s.mutex.Lock()
+	entries := append([]*logEntry(nil), s.logEntries...)
+	s.mutex.Unlock()
+	for idx, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		infoParts := []string{entry.Name}
+		if entry.Info != nil {
+			infoParts = append(infoParts,
+				entry.Info.Status,
+				formatLogTime(jobStartTime(entry.Info)),
+				formatLogTime(jobFinishTime(entry.Info)),
+			)
+		}
+		if containsQuery(strings.Join(infoParts, " "), query) {
+			row := idx + 1
+			s.queueUpdate(func() {
+				s.serviceTable.Select(row, 0)
+				s.handleLogSelection(row, true)
+			})
+			return true
+		}
+	}
+	return false
+}
+
+func (s *uiState) searchDetails(query string) bool {
+	text := s.detailsView.GetText(true)
+	lines := strings.Split(text, "\n")
+	for idx, line := range lines {
+		if containsQuery(line, query) {
+			lineNum := idx
+			s.queueUpdate(func() {
+				s.detailsView.ScrollTo(lineNum, 0)
+			})
+			return true
+		}
+	}
+	return false
+}
+
+func containsQuery(haystack, query string) bool {
+	return strings.Contains(strings.ToLower(haystack), query)
+}

--- a/pkg/tui/services_view.go
+++ b/pkg/tui/services_view.go
@@ -1,0 +1,504 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rivo/tview"
+
+	"github.com/grycap/oscar-cli/pkg/service"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+func (s *uiState) markServicePanelVisited() {
+	s.mutex.Lock()
+	already := s.servicePanelVisited
+	s.servicePanelVisited = true
+	row, _ := s.serviceTable.GetSelection()
+	s.mutex.Unlock()
+	if already {
+		return
+	}
+	if row > 0 {
+		s.handleSelection(row, true)
+		return
+	}
+	s.setServiceDetailsText("Select a service to inspect details")
+}
+
+func (s *uiState) serviceDetailsEnabled() bool {
+	s.mutex.Lock()
+	visited := s.servicePanelVisited
+	s.mutex.Unlock()
+	return visited
+}
+
+func (s *uiState) setServiceDetailsText(text string) {
+	if !s.serviceDetailsEnabled() {
+		return
+	}
+	s.queueUpdate(func() {
+		s.detailsView.SetText(text)
+	})
+}
+
+func (s *uiState) switchToServices(ctx context.Context) {
+	if s.searchVisible {
+		s.hideSearch()
+	}
+	s.mutex.Lock()
+	if s.confirmVisible || s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	if s.mode == modeServices {
+		s.mutex.Unlock()
+		return
+	}
+	s.mode = modeServices
+	s.currentLogsKey = ""
+	s.currentLogJobKey = ""
+	s.currentLogService = ""
+	s.currentLogCluster = ""
+	s.logEntries = nil
+	if s.bucketCancel != nil {
+		s.bucketCancel()
+		s.bucketCancel = nil
+	}
+	if s.bucketObjectsCancel != nil {
+		s.bucketObjectsCancel()
+		s.bucketObjectsCancel = nil
+	}
+	if s.detailTimer != nil {
+		s.detailTimer.Stop()
+		s.detailTimer = nil
+	}
+	s.lastSelection = ""
+	s.currentBucketObjectsKey = ""
+	services := s.currentServices
+	clusterName := s.currentCluster
+	s.mutex.Unlock()
+
+	s.hideBucketObjectsPane()
+	s.showClusterDetails(clusterName)
+
+	if len(services) > 0 {
+		s.renderServiceTable(services)
+		s.setStatus(fmt.Sprintf("[green]Loaded %d service(s) for %s", len(services), clusterName))
+		return
+	}
+
+	if clusterName == "" {
+		s.queueUpdate(func() {
+			s.showServiceMessage("Select a cluster to view services")
+		})
+		return
+	}
+
+	s.queueUpdate(func() {
+		s.showServiceMessage("Loading…")
+	})
+	go s.loadServices(ctx, clusterName, true)
+}
+
+func (s *uiState) loadServices(ctx context.Context, name string, force bool) {
+	if name == "" {
+		return
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			s.mutex.Lock()
+			s.refreshing = false
+			s.loadingCluster = ""
+			s.mutex.Unlock()
+			s.setStatus(fmt.Sprintf("[red]Unexpected error while loading services for %s: %v", name, r))
+		}
+	}()
+
+	cfg, ok := s.conf.Oscar[name]
+	if !ok || cfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q not found in configuration", name))
+		s.mutex.Lock()
+		s.refreshing = false
+		s.loadingCluster = ""
+		s.currentServices = nil
+		s.failedClusters[name] = fmt.Sprintf("Cluster %q not found in configuration", name)
+		s.mutex.Unlock()
+		s.queueUpdate(func() {
+			s.showServiceMessage("Cluster not found")
+		})
+		return
+	}
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading services for cluster %s…", name))
+	s.queueUpdate(func() {
+		s.showServiceMessage("Loading…")
+	})
+
+	s.mutex.Lock()
+	if s.refreshing && !force && s.loadingCluster == name {
+		s.mutex.Unlock()
+		return
+	}
+	if s.loadCancel != nil {
+		s.loadCancel()
+		s.loadCancel = nil
+	}
+	if s.detailTimer != nil {
+		s.detailTimer.Stop()
+		s.detailTimer = nil
+	}
+	s.lastSelection = ""
+	s.loadSeq++
+	loadVersion := s.loadSeq
+	ctxFetch, cancel := context.WithTimeout(ctx, 15*time.Second)
+	s.refreshing = true
+	s.loadingCluster = name
+	s.loadCancel = cancel
+	s.mutex.Unlock()
+
+	servicesList, err := service.ListServicesWithContext(ctxFetch, cfg)
+	if err != nil {
+		message := fmt.Sprintf("Unable to load services for %s: %v", name, err)
+		s.setStatus(fmt.Sprintf("[red]%s", message))
+		s.mutex.Lock()
+		if loadVersion == s.loadSeq {
+			s.failedClusters[name] = message
+			s.refreshing = false
+			s.loadingCluster = ""
+			s.currentServices = nil
+			s.loadCancel = nil
+		}
+		s.mutex.Unlock()
+		s.queueUpdate(func() {
+			s.showServiceMessage("Unable to load services")
+		})
+		cancel()
+		return
+	}
+	if ctx.Err() != nil {
+		s.mutex.Lock()
+		if loadVersion == s.loadSeq {
+			s.refreshing = false
+			s.loadingCluster = ""
+			s.currentServices = nil
+			s.loadCancel = nil
+		}
+		s.mutex.Unlock()
+		cancel()
+		return
+	}
+
+	cancel()
+	s.mutex.Lock()
+	if loadVersion != s.loadSeq {
+		s.mutex.Unlock()
+		return
+	}
+	if s.currentCluster == name {
+		s.currentServices = servicesList
+		delete(s.failedClusters, name)
+	}
+	s.refreshing = false
+	s.loadingCluster = ""
+	s.loadCancel = nil
+	currentMode := s.mode
+	s.mutex.Unlock()
+
+	if currentMode == modeServices && s.currentCluster == name {
+		s.renderServiceTable(servicesList)
+		s.setStatus(fmt.Sprintf("[green]Loaded %d service(s) for %s", len(servicesList), name))
+	}
+}
+
+func (s *uiState) handleServiceSelection(row int, immediate bool) {
+	s.mutex.Lock()
+	if s.mode != modeServices {
+		if s.detailTimer != nil {
+			s.detailTimer.Stop()
+			s.detailTimer = nil
+		}
+		s.mutex.Unlock()
+		return
+	}
+	enabled := s.servicePanelVisited
+	if row <= 0 || row-1 >= len(s.currentServices) {
+		if s.detailTimer != nil {
+			s.detailTimer.Stop()
+			s.detailTimer = nil
+		}
+		s.lastSelection = ""
+		s.mutex.Unlock()
+		if enabled {
+			s.setServiceDetailsText("Select a service to inspect details")
+		}
+		return
+	}
+	svcPtr := s.currentServices[row-1]
+	if svcPtr == nil {
+		s.mutex.Unlock()
+		return
+	}
+	svc := *svcPtr
+	token := fmt.Sprintf("%s-%d-%d", svc.Name, row, s.loadSeq)
+	if s.detailTimer != nil {
+		s.detailTimer.Stop()
+		s.detailTimer = nil
+	}
+	s.lastSelection = token
+	s.mutex.Unlock()
+
+	if !enabled {
+		return
+	}
+
+	if immediate {
+		s.showServiceDefinition(s.currentCluster, svc.Name)
+		return
+	}
+
+	timer := time.AfterFunc(1*time.Second, func() {
+		s.mutex.Lock()
+		if s.lastSelection != token {
+			s.mutex.Unlock()
+			return
+		}
+		s.detailTimer = nil
+		s.mutex.Unlock()
+		s.showServiceDefinition(s.currentCluster, svc.Name)
+	})
+
+	s.mutex.Lock()
+	if s.lastSelection == token {
+		s.detailTimer = timer
+	} else {
+		timer.Stop()
+	}
+	s.mutex.Unlock()
+}
+
+func (s *uiState) performDeletion(clusterName, svcName string) {
+	s.setStatus(fmt.Sprintf("[yellow]Deleting service %q...", svcName))
+	s.mutex.Lock()
+	if s.detailTimer != nil {
+		s.detailTimer.Stop()
+		s.detailTimer = nil
+	}
+	s.lastSelection = ""
+	s.mutex.Unlock()
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+	if err := service.RemoveService(clusterCfg, svcName); err != nil {
+		s.setStatus(fmt.Sprintf("[red]Failed to delete service %q: %v", svcName, err))
+		return
+	}
+	s.setStatus(fmt.Sprintf("[green]Service %q deleted", svcName))
+	s.setServiceDetailsText("Select a service to inspect details")
+	s.refreshCurrent(context.Background())
+}
+
+func (s *uiState) renderServiceTable(services []*types.Service) {
+	s.queueUpdate(func() {
+		s.serviceTable.SetTitle("Services")
+		setServiceTableHeader(s.serviceTable)
+		if len(services) == 0 {
+			fillMessageRow(s.serviceTable, len(serviceHeaders), "No services found")
+			return
+		}
+		for i, svc := range services {
+			row := i + 1
+			s.serviceTable.SetCell(row, 0, tview.NewTableCell(svc.Name).
+				SetExpansion(2).
+				SetSelectable(true)).
+				SetCell(row, 1, tview.NewTableCell(truncateString(svc.Image, 40)).
+					SetExpansion(4)).
+				SetCell(row, 2, tview.NewTableCell(defaultIfEmpty(svc.CPU, "-")).
+					SetExpansion(1)).
+				SetCell(row, 3, tview.NewTableCell(defaultIfEmpty(svc.Memory, "-")).
+					SetExpansion(1))
+		}
+		row, col := s.serviceTable.GetSelection()
+		if row <= 0 || row > len(services) {
+			s.serviceTable.Select(1, 0)
+		} else {
+			s.serviceTable.Select(row, col)
+		}
+	})
+}
+
+func (s *uiState) showServiceMessage(message string) {
+	s.serviceTable.SetTitle("Services")
+	setServiceTableHeader(s.serviceTable)
+	fillMessageRow(s.serviceTable, len(serviceHeaders), message)
+}
+
+func (s *uiState) searchServices(query string) bool {
+	s.mutex.Lock()
+	services := append([]*types.Service(nil), s.currentServices...)
+	s.mutex.Unlock()
+	for idx, svc := range services {
+		if svc == nil {
+			continue
+		}
+		fields := []string{svc.Name, svc.Image, svc.CPU, svc.Memory}
+		if containsQuery(strings.Join(fields, " "), query) {
+			row := idx + 1
+			s.queueUpdate(func() {
+				s.serviceTable.Select(row, 0)
+				s.handleServiceSelection(row, true)
+			})
+			return true
+		}
+	}
+	return false
+}
+
+func (s *uiState) showServiceDefinition(clusterName, serviceName string) {
+	clusterName = strings.TrimSpace(clusterName)
+	serviceName = strings.TrimSpace(serviceName)
+	if clusterName == "" || serviceName == "" {
+		s.setServiceDetailsText("Select a service to inspect details")
+		return
+	}
+
+	key := makeServiceDefinitionKey(clusterName, serviceName)
+	s.mutex.Lock()
+	cached := s.serviceDefinitions[key]
+	s.serviceDefinitionSeq++
+	seq := s.serviceDefinitionSeq
+	s.currentServiceDefinition = key
+	s.mutex.Unlock()
+
+	if cached != "" {
+		s.queueUpdate(func() {
+			s.detailsView.SetText(cached)
+		})
+		return
+	}
+
+	loadingText := fmt.Sprintf("Loading definition for %s…", serviceName)
+	s.queueUpdate(func() {
+		s.detailsView.SetText(loadingText)
+	})
+	s.setStatus(fmt.Sprintf("[yellow]Loading definition for %q…", serviceName))
+
+	go s.fetchServiceDefinition(clusterName, serviceName, key, seq)
+}
+
+func (s *uiState) fetchServiceDefinition(clusterName, serviceName, key string, seq int) {
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+
+	def, err := service.GetService(clusterCfg, serviceName)
+	if err != nil {
+		s.setStatus(fmt.Sprintf("[red]Failed to load definition for %q: %v", serviceName, err))
+		return
+	}
+
+	rendered, err := formatServiceDefinition(def)
+	if err != nil {
+		s.setStatus(fmt.Sprintf("[red]Failed to format definition for %q: %v", serviceName, err))
+		return
+	}
+
+	s.mutex.Lock()
+	if seq != s.serviceDefinitionSeq {
+		s.mutex.Unlock()
+		return
+	}
+	s.serviceDefinitions[key] = rendered
+	active := s.currentServiceDefinition
+	s.mutex.Unlock()
+
+	if active == key {
+		s.queueUpdate(func() {
+			s.detailsView.SetText(rendered)
+		})
+		s.setStatus(fmt.Sprintf("[green]Loaded definition for %q", serviceName))
+	}
+}
+
+func makeServiceDefinitionKey(clusterName, serviceName string) string {
+	return fmt.Sprintf("%s\x00%s", clusterName, serviceName)
+}
+
+func formatServiceDefinition(svc *types.Service) (string, error) {
+	if svc == nil {
+		return "", nil
+	}
+
+	data, err := json.Marshal(svc)
+	if err != nil {
+		return "", err
+	}
+	var val interface{}
+	if err := json.Unmarshal(data, &val); err != nil {
+		return "", err
+	}
+	builder := &strings.Builder{}
+	colorizeJSON(builder, val, 0)
+	return builder.String(), nil
+}
+
+func colorizeJSON(builder *strings.Builder, val interface{}, level int) {
+	indent := strings.Repeat("  ", level)
+	switch v := val.(type) {
+	case map[string]interface{}:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		builder.WriteString("{\n")
+		for i, k := range keys {
+			builder.WriteString(indent + "  ")
+			builder.WriteString("[yellow]")
+			builder.WriteString(tview.Escape(k))
+			builder.WriteString("[-]: ")
+			colorizeJSON(builder, v[k], level+1)
+			if i < len(keys)-1 {
+				builder.WriteString(",")
+			}
+			builder.WriteString("\n")
+		}
+		builder.WriteString(indent + "}")
+	case []interface{}:
+		builder.WriteString("[\n")
+		for i, item := range v {
+			builder.WriteString(indent + "  ")
+			colorizeJSON(builder, item, level+1)
+			if i < len(v)-1 {
+				builder.WriteString(",")
+			}
+			builder.WriteString("\n")
+		}
+		builder.WriteString(indent + "]")
+	case string:
+		builder.WriteString("[green]\"")
+		builder.WriteString(tview.Escape(v))
+		builder.WriteString("\"[-]")
+	case float64, int, int64, uint64, float32:
+		builder.WriteString("[cyan]")
+		builder.WriteString(fmt.Sprintf("%v", v))
+		builder.WriteString("[-]")
+	case bool:
+		builder.WriteString("[magenta]")
+		builder.WriteString(fmt.Sprintf("%v", v))
+		builder.WriteString("[-]")
+	case nil:
+		builder.WriteString("[gray]null[-]")
+	default:
+		builder.WriteString(tview.Escape(fmt.Sprintf("%v", v)))
+	}
+}

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -1,0 +1,141 @@
+package tui
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rivo/tview"
+
+	"github.com/grycap/oscar-cli/pkg/config"
+	"github.com/grycap/oscar-cli/pkg/storage"
+	"github.com/grycap/oscar/v3/pkg/types"
+)
+
+const legendText = `[yellow]Navigation[-]
+  ↑/↓  Move selection
+  ←/→ or Tab  Switch pane
+  v  Focus details panel
+
+[yellow]Actions[-]
+  r  Refresh current view
+  d  Delete selected item
+  i  Show cluster info
+  l  Open logs panel
+  w  Configure auto refresh
+  b  Switch to buckets view
+  s  Switch to services view
+  Enter  Focus bucket objects (bucket view)
+  o  Reload bucket objects (bucket view)
+  n/p  Next/previous bucket objects page
+  a  Load all bucket objects
+  q  Quit
+  ?  Toggle this help`
+
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d[::-] Delete selection · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+
+type panelMode int
+
+const (
+	modeServices panelMode = iota
+	modeBuckets
+	modeLogs
+)
+
+var (
+	serviceHeaders      = []string{"Name", "Image", "CPU", "Memory"}
+	bucketHeaders       = []string{"Name", "Visibility", "Owner"}
+	bucketObjectHeaders = []string{"Name", "Size (B)", "Last Modified"}
+	logHeaders          = []string{"Job", "Status", "Started", "Finished"}
+)
+
+type searchTarget int
+
+const (
+	searchTargetNone searchTarget = iota
+	searchTargetClusters
+	searchTargetServices
+	searchTargetLogs
+	searchTargetBuckets
+	searchTargetDetails
+)
+
+type uiState struct {
+	app                *tview.Application
+	conf               *config.Config
+	rootCtx            context.Context
+	statusView         *tview.TextView
+	detailsView        *tview.TextView
+	detailContainer    *tview.Flex
+	serviceTable       *tview.Table
+	bucketObjectsTable *tview.Table
+	clusterList        *tview.List
+	statusContainer    *tview.Flex
+	pages              *tview.Pages
+	mutex              *sync.Mutex
+
+	clusterNames             []string
+	currentCluster           string
+	currentServices          []*types.Service
+	refreshing               bool
+	started                  bool
+	pendingCluster           string
+	loadingCluster           string
+	failedClusters           map[string]string
+	loadCancel               context.CancelFunc
+	loadSeq                  int
+	detailTimer              *time.Timer
+	lastSelection            string
+	legendVisible            bool
+	confirmVisible           bool
+	savedFocus               tview.Primitive
+	mode                     panelMode
+	bucketInfos              []*storage.BucketInfo
+	bucketCancel             context.CancelFunc
+	bucketSeq                int
+	bucketCluster            string
+	bucketObjectsVisible     bool
+	bucketObjects            map[string]*bucketObjectState
+	currentBucketObjectsKey  string
+	bucketObjectsCancel      context.CancelFunc
+	bucketObjectsSeq         int
+	searchVisible            bool
+	searchInput              *tview.InputField
+	searchTarget             searchTarget
+	originalFocus            tview.Primitive
+	serviceDefinitions       map[string]string
+	serviceDefinitionSeq     int
+	currentServiceDefinition string
+	autoRefreshCancel        context.CancelFunc
+	autoRefreshTicker        *time.Ticker
+	autoRefreshPeriod        time.Duration
+	autoRefreshActive        bool
+	autoRefreshPromptVisible bool
+	autoRefreshInput         *tview.InputField
+	autoRefreshFocus         tview.Primitive
+	servicePanelVisited      bool
+	logEntries               []*logEntry
+	logDetails               map[string]string
+	logSeq                   int
+	logDetailSeq             int
+	currentLogsKey           string
+	currentLogJobKey         string
+	currentLogService        string
+	currentLogCluster        string
+}
+
+type bucketObjectState struct {
+	Objects       []*storage.BucketObject
+	NextPage      string
+	PrevTokens    []string
+	CurrentToken  string
+	IsTruncated   bool
+	Auto          bool
+	ReturnedItems int
+}
+
+type bucketObjectRequest struct {
+	Token      string
+	PrevTokens []string
+	Auto       bool
+}

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -19,7 +19,7 @@ const legendText = `[yellow]Navigation[-]
 
 [yellow]Actions[-]
   r  Refresh current view
-  d  Delete selected item
+  d or Del  Delete selected service/bucket
   i  Show cluster info
   l  Open logs panel
   w  Configure auto refresh
@@ -32,7 +32,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d[::-] Delete selection · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 

--- a/pkg/tui/table_helpers.go
+++ b/pkg/tui/table_helpers.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func setServiceTableHeader(table *tview.Table) {
+	setTableHeader(table, serviceHeaders)
+}
+
+func setLogTableHeader(table *tview.Table) {
+	setTableHeader(table, logHeaders)
+}
+
+func setBucketTableHeader(table *tview.Table) {
+	setTableHeader(table, bucketHeaders)
+}
+
+func setBucketObjectTableHeader(table *tview.Table) {
+	setTableHeader(table, bucketObjectHeaders)
+}
+
+func setTableHeader(table *tview.Table, headers []string) {
+	table.Clear()
+	for col, header := range headers {
+		table.SetCell(0, col, tview.NewTableCell(header).
+			SetTextColor(tcell.ColorWhite).
+			SetSelectable(false).
+			SetAttributes(tcell.AttrBold))
+	}
+}
+
+func fillMessageRow(table *tview.Table, columns int, message string) {
+	table.SetCell(1, 0, tview.NewTableCell(message).
+		SetAlign(tview.AlignCenter).
+		SetSelectable(false).
+		SetExpansion(columns))
+	for col := 1; col < columns; col++ {
+		table.SetCell(1, col, tview.NewTableCell("").SetSelectable(false))
+	}
+}
+
+func bucketVisibilityColor(vis string) tcell.Color {
+	switch strings.ToLower(strings.TrimSpace(vis)) {
+	case "restricted":
+		return tcell.ColorYellow
+	case "private":
+		return tcell.ColorRed
+	case "public":
+		return tcell.ColorGreen
+	default:
+		return tcell.ColorWhite
+	}
+}


### PR DESCRIPTION
What Changed

  - Enabled deletion from Buckets view using the same confirmation flow already used for services.
  - Updated key handling so deletion works when:
      - Focus is on the main table.
      - Mode is either Services or Buckets.
  - Added Del as an alias to d for delete.
  - Updated TUI help text and legend to reflect service/bucket deletion behavior.

  Key Binding

  - d (primary)
  - Del (alias)

  Both now delete the selected item in the current table context:

  - Services view: selected service
  - Buckets view: selected bucket (DEL /system/buckets/{bucketName})

  Files Updated

  - pkg/tui/app.go
  - pkg/tui/state.go

  Validation

  - GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./pkg/tui passed.

  Impact

  - No API changes.
  - No new deletion logic in storage layer; this PR wires existing bucket deletion functionality into TUI key handling and user
    guidance.