### PR TITLE
Support bucket deletion in TUI (clean PR to devel)

### DIFF
--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -192,6 +192,11 @@ func Run(ctx context.Context, conf *config.Config) error {
 				state.switchToLogs(ctx)
 				return nil
 			}
+		case tcell.KeyDelete:
+			if app.GetFocus() == state.serviceTable && (state.modeIsServices() || state.modeIsBuckets()) {
+				state.requestDeletion()
+				return nil
+			}
 		}
 
 		switch event.Rune() {
@@ -232,7 +237,7 @@ func Run(ctx context.Context, conf *config.Config) error {
 				return nil
 			}
 		case 'd', 'D':
-			if app.GetFocus() == state.serviceTable && state.modeIsServices() {
+			if app.GetFocus() == state.serviceTable && (state.modeIsServices() || state.modeIsBuckets()) {
 				state.requestDeletion()
 				return nil
 			}

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -19,7 +19,7 @@ const legendText = `[yellow]Navigation[-]
 
 [yellow]Actions[-]
   r  Refresh current view
-  d  Delete selected item
+  d or Del  Delete selected service/bucket
   i  Show cluster info
   l  Open logs panel
   w  Configure auto refresh
@@ -32,7 +32,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d[::-] Delete selection · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 


### PR DESCRIPTION
## Summary
- enable deletion with `Del` key in TUI
- allow deletion action in both Services and Buckets views
- update TUI help text to reflect `d/Del` behavior

## Scope
This PR is intentionally clean and contains only bucket/service deletion UX changes in TUI.

## Validation
- `go test ./pkg/tui/...` passes
- full `go test ./...` currently fails due to pre-existing unrelated failures in `cmd/service_run_test.go`
