### PR TITLE
feat: support exposed-service acceptance commands in hub validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Default curated source: https://github.com/grycap/oscar-hub/tree/main
 
 Run the acceptance tests defined in a curated RO-Crate against a deployed service.
 
+The validator understands the structured acceptance steps currently used in OSCAR Hub RO-Crates, including synchronous `service run`, staged `put-file` / `get-file` flows, waits, and exposed-service HTTP checks with multipart uploads and response media validation.
+
 ```
 Usage:
   oscar-cli hub validate SERVICE-SLUG [flags]

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Flags:
       --local-path string  use a local directory containing the RO-Crate metadata instead of fetching it from GitHub
       --owner string     GitHub owner that hosts the curated services (default "grycap")
       --path string      subdirectory inside the repository that contains the services
+      --print-acceptance-commands  print the acceptance test shell commands instead of executing them
       --ref string       Git reference (branch, tag, or commit) to query (default "main")
   -n, --name string      override the OSCAR service name during validation
       --repo string      GitHub repository that hosts the curated services (default "oscar-hub")

--- a/cmd/hub_validate.go
+++ b/cmd/hub_validate.go
@@ -27,13 +27,14 @@ import (
 )
 
 type hubValidateOptions struct {
-	owner     string
-	repo      string
-	rootPath  string
-	ref       string
-	apiBase   string
-	name      string
-	localPath string
+	owner                   string
+	repo                    string
+	rootPath                string
+	ref                     string
+	apiBase                 string
+	name                    string
+	localPath               string
+	printAcceptanceCommands bool
 }
 
 func (o *hubValidateOptions) applyToClient() []hub.Option {
@@ -67,9 +68,36 @@ func hubValidateFunc(cmd *cobra.Command, args []string, opts *hubValidateOptions
 	}
 
 	out := cmd.OutOrStdout()
+	client := hub.NewClient(append(opts.applyToClient(), hub.WithLogWriter(out))...)
+	if opts.printAcceptanceCommands {
+		fmt.Fprintf(out, "Acceptance commands for %s\n", args[0])
+		sets, err := client.AcceptanceCommands(cmd.Context(), args[0], opts.name, opts.localPath)
+		if err != nil {
+			return err
+		}
+		serviceName := strings.TrimSpace(opts.name)
+		if serviceName == "" {
+			serviceName = args[0]
+		}
+		if requiresEndpointOrToken(sets) {
+			fmt.Fprintf(out, "export OSCAR_ENDPOINT=%q\n", conf.Oscar[clusterID].Endpoint)
+			fmt.Fprintf(out, "export SERVICE_TOKEN=\"$(oscar-cli service get %s -c %s | awk '/^token:/{print $2; exit}')\"\n", serviceName, clusterID)
+		}
+		for _, set := range sets {
+			name := strings.TrimSpace(set.Test.Name)
+			if name == "" {
+				name = set.Test.ID
+			}
+			fmt.Fprintf(out, "# %s\n", name)
+			for _, command := range set.Commands {
+				fmt.Fprintln(out, command)
+			}
+		}
+		return nil
+	}
+
 	fmt.Fprintf(out, "Acceptance tests for %s\n", args[0])
 
-	client := hub.NewClient(append(opts.applyToClient(), hub.WithLogWriter(out))...)
 	results, err := client.ValidateService(cmd.Context(), args[0], conf.Oscar[clusterID], opts.name, opts.localPath)
 	if err != nil {
 		return err
@@ -87,6 +115,17 @@ func hubValidateFunc(cmd *cobra.Command, args []string, opts *hubValidateOptions
 	}
 
 	return nil
+}
+
+func requiresEndpointOrToken(sets []hub.AcceptanceCommandSet) bool {
+	for _, set := range sets {
+		for _, command := range set.Commands {
+			if strings.Contains(command, "${OSCAR_ENDPOINT") || strings.Contains(command, "${SERVICE_TOKEN}") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func makeHubValidateCmd() *cobra.Command {
@@ -115,6 +154,7 @@ func makeHubValidateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.apiBase, "api-base", "", "override the GitHub API base URL")
 	cmd.Flags().StringVarP(&opts.name, "name", "n", "", "override the OSCAR service name during validation")
 	cmd.Flags().StringVar(&opts.localPath, "local-path", "", "use a local directory containing the RO-Crate metadata instead of fetching it from GitHub")
+	cmd.Flags().BoolVar(&opts.printAcceptanceCommands, "print-acceptance-commands", false, "print the acceptance test shell commands instead of executing them")
 	if flag := cmd.Flags().Lookup("api-base"); flag != nil {
 		flag.Hidden = true
 	}

--- a/cmd/hub_validate_test.go
+++ b/cmd/hub_validate_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/grycap/oscar-cli/pkg/hub"
+)
+
+func TestMakeHubValidateCmdIncludesPrintAcceptanceCommandsFlag(t *testing.T) {
+	cmd := makeHubValidateCmd()
+	flag := cmd.Flags().Lookup("print-acceptance-commands")
+	if flag == nil {
+		t.Fatalf("expected print-acceptance-commands flag to be registered")
+	}
+}
+
+func TestRequiresEndpointOrToken(t *testing.T) {
+	sets := []hub.AcceptanceCommandSet{
+		{Commands: []string{"echo hello"}},
+	}
+	if requiresEndpointOrToken(sets) {
+		t.Fatalf("expected false when commands do not use endpoint/token placeholders")
+	}
+
+	sets = []hub.AcceptanceCommandSet{
+		{Commands: []string{"curl '${OSCAR_ENDPOINT%/}/system/services/demo/exposed' -u demo:${SERVICE_TOKEN}"}},
+	}
+	if !requiresEndpointOrToken(sets) {
+		t.Fatalf("expected true when command uses endpoint/token placeholders")
+	}
+}

--- a/pkg/hub/rocrate.go
+++ b/pkg/hub/rocrate.go
@@ -326,6 +326,9 @@ func (c *ROCrate) parseStructuredSteps(testID string, node map[string]interface{
 
 			if parsedCmd, ok := c.buildParsedCommand(paMap, step.Inputs); ok {
 				step.ParsedCommand = parsedCmd
+				if strings.TrimSpace(step.Command) == "" {
+					step.Command = describeParsedCommand(*parsedCmd)
+				}
 			}
 		} else if duration := strings.TrimSpace(readString(stepMap, "timeRequired")); duration != "" {
 			if parsedCmd, err := buildWaitCommand(duration); err == nil {
@@ -458,6 +461,27 @@ func (c *ROCrate) buildParsedCommand(action map[string]interface{}, inputs []Tes
 			Kind:            stepCommandGetFile,
 			LatestRequested: strings.Contains(template, "--download-latest-into"),
 		}, true
+	case "http-request", "exposed-http", "http":
+		method := strings.ToUpper(strings.TrimSpace(c.propertyValue(action["additionalProperty"], "method")))
+		if method == "" {
+			method = "GET"
+		}
+		requestPath := strings.TrimSpace(c.propertyValue(action["additionalProperty"], "path"))
+		if requestPath == "" {
+			requestPath = strings.TrimSpace(c.propertyValue(action["target"], "urlTemplate"))
+		}
+		if requestPath == "" {
+			return nil, false
+		}
+		return &parsedCommand{
+			Kind:               stepCommandHTTP,
+			HTTPMethod:         method,
+			HTTPPath:           requestPath,
+			HTTPAccept:         strings.TrimSpace(c.propertyValue(action["additionalProperty"], "accept")),
+			HTTPFormField:      firstNonEmpty(strings.TrimSpace(c.propertyValue(action["additionalProperty"], "formField")), "file"),
+			HTTPUseServiceAuth: !strings.EqualFold(strings.TrimSpace(c.propertyValue(action["additionalProperty"], "auth")), "none"),
+			HTTPExpectStatus:   parseStatusOrDefault(c.propertyValue(action["additionalProperty"], "status"), 200),
+		}, true
 	}
 
 	if strings.Contains(template, "service run") {
@@ -477,6 +501,11 @@ func (c *ROCrate) buildParsedCommand(action map[string]interface{}, inputs []Tes
 			Kind:            stepCommandGetFile,
 			LatestRequested: strings.Contains(template, "--download-latest-into"),
 		}, true
+	}
+	if strings.Contains(strings.ToLower(template), "service http") {
+		if parsedCmd, err := parseAcceptanceCommand(template); err == nil {
+			return &parsedCmd, true
+		}
 	}
 
 	return nil, false
@@ -508,6 +537,22 @@ func (c *ROCrate) commandTemplate(raw interface{}) string {
 	nodes := c.propertyNodes(raw)
 	for _, node := range nodes {
 		if propertyID := strings.TrimSpace(readString(node, "propertyID")); strings.EqualFold(propertyID, "commandTemplate") {
+			if value := strings.TrimSpace(readString(node, "value")); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func (c *ROCrate) propertyValue(raw interface{}, propertyID string) string {
+	propertyID = strings.TrimSpace(propertyID)
+	if propertyID == "" {
+		return ""
+	}
+	nodes := c.propertyNodes(raw)
+	for _, node := range nodes {
+		if strings.EqualFold(strings.TrimSpace(readString(node, "propertyID")), propertyID) {
 			if value := strings.TrimSpace(readString(node, "value")); value != "" {
 				return value
 			}
@@ -583,6 +628,39 @@ func parsePosition(value interface{}) int {
 		}
 	}
 	return 0
+}
+
+func parseStatusOrDefault(raw string, fallback int) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+func describeParsedCommand(cmd parsedCommand) string {
+	switch cmd.Kind {
+	case stepCommandRun:
+		return "service run"
+	case stepCommandPutFile:
+		return "service put-file"
+	case stepCommandGetFile:
+		return "service get-file"
+	case stepCommandWait:
+		return fmt.Sprintf("wait %s", cmd.WaitDuration)
+	case stepCommandHTTP:
+		method := strings.TrimSpace(cmd.HTTPMethod)
+		if method == "" {
+			method = "GET"
+		}
+		return fmt.Sprintf("service http %s %s", method, strings.TrimSpace(cmd.HTTPPath))
+	default:
+		return ""
+	}
 }
 
 func buildWaitCommand(raw string) (*parsedCommand, error) {

--- a/pkg/hub/rocrate_test.go
+++ b/pkg/hub/rocrate_test.go
@@ -145,3 +145,121 @@ func TestAcceptanceTestsIncludesStructuredSteps(t *testing.T) {
 		t.Fatalf("expected media type image/png, got %+v", getStep.ExpectedMedia)
 	}
 }
+
+func TestAcceptanceTestsIncludesStructuredHTTPStep(t *testing.T) {
+	raw := []byte(`{
+		"@graph": [
+			{
+				"@id": "./",
+				"subjectOf": [{ "@id": "#acceptance-http" }]
+			},
+			{
+				"@id": "001.jpg",
+				"@type": ["File", "ImageObject"],
+				"name": "Sample input image",
+				"encodingFormat": "image/jpeg"
+			},
+			{
+				"@id": "#expected-zip",
+				"@type": ["File", "MediaObject"],
+				"encodingFormat": "application/zip"
+			},
+			{
+				"@id": "#acceptance-http",
+				"@type": "HowTo",
+				"name": "HTTP acceptance test",
+				"step": [{ "@id": "#step-http" }]
+			},
+			{
+				"@id": "#step-http",
+				"@type": "HowToStep",
+				"position": 1,
+				"potentialAction": { "@id": "#action-http" }
+			},
+			{
+				"@id": "#action-http",
+				"@type": "ConsumeAction",
+				"name": "http-request",
+				"object": { "@id": "001.jpg" },
+				"result": { "@id": "#expected-zip" },
+				"additionalProperty": [
+					{
+						"@id": "#prop-method"
+					},
+					{
+						"@id": "#prop-path"
+					},
+					{
+						"@id": "#prop-accept"
+					},
+					{
+						"@id": "#prop-field"
+					}
+				]
+			},
+			{
+				"@id": "#prop-method",
+				"@type": "PropertyValue",
+				"propertyID": "method",
+				"value": "POST"
+			},
+			{
+				"@id": "#prop-path",
+				"@type": "PropertyValue",
+				"propertyID": "path",
+				"value": "/v2/models/posenetclas/predict/"
+			},
+			{
+				"@id": "#prop-accept",
+				"@type": "PropertyValue",
+				"propertyID": "accept",
+				"value": "application/zip"
+			},
+			{
+				"@id": "#prop-field",
+				"@type": "PropertyValue",
+				"propertyID": "formField",
+				"value": "data"
+			}
+		]
+	}`)
+
+	crate, err := ParseROCrate(raw)
+	if err != nil {
+		t.Fatalf("ParseROCrate returned error: %v", err)
+	}
+
+	tests, err := crate.AcceptanceTests()
+	if err != nil {
+		t.Fatalf("AcceptanceTests returned error: %v", err)
+	}
+
+	if len(tests) != 1 {
+		t.Fatalf("expected 1 acceptance test, got %d", len(tests))
+	}
+
+	test := tests[0]
+	if len(test.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(test.Steps))
+	}
+
+	step := test.Steps[0]
+	if step.ParsedCommand == nil || step.ParsedCommand.Kind != stepCommandHTTP {
+		t.Fatalf("expected stepCommandHTTP, got %+v", step.ParsedCommand)
+	}
+	if step.ParsedCommand.HTTPMethod != "POST" {
+		t.Fatalf("unexpected HTTP method %q", step.ParsedCommand.HTTPMethod)
+	}
+	if step.ParsedCommand.HTTPPath != "/v2/models/posenetclas/predict/" {
+		t.Fatalf("unexpected HTTP path %q", step.ParsedCommand.HTTPPath)
+	}
+	if step.ParsedCommand.HTTPFormField != "data" {
+		t.Fatalf("unexpected form field %q", step.ParsedCommand.HTTPFormField)
+	}
+	if len(step.ExpectedMedia) != 1 || step.ExpectedMedia[0] != "application/zip" {
+		t.Fatalf("unexpected expected media %+v", step.ExpectedMedia)
+	}
+	if step.Command != "service http POST /v2/models/posenetclas/predict/" {
+		t.Fatalf("unexpected synthetic command %q", step.Command)
+	}
+}

--- a/pkg/hub/validate.go
+++ b/pkg/hub/validate.go
@@ -82,6 +82,12 @@ type parsedCommand struct {
 	HTTPExpectStatus   int
 }
 
+// AcceptanceCommandSet stores runnable shell commands for a single acceptance test.
+type AcceptanceCommandSet struct {
+	Test     AcceptanceTest
+	Commands []string
+}
+
 // ValidateService downloads the RO-Crate metadata for the provided slug, runs its acceptance tests against the cluster and returns the aggregated results.
 func (c *Client) ValidateService(ctx context.Context, slug string, clusterCfg *cluster.Cluster, serviceNameOverride string, localRoot string) ([]AcceptanceResult, error) {
 	if strings.TrimSpace(slug) == "" {
@@ -91,34 +97,7 @@ func (c *Client) ValidateService(ctx context.Context, slug string, clusterCfg *c
 		return nil, errors.New("cluster configuration is required")
 	}
 
-	var (
-		repoPath       string
-		localCratePath string
-		rawMetadata    []byte
-		err            error
-	)
-
-	localRoot = strings.TrimSpace(localRoot)
-	if localRoot != "" {
-		rawMetadata, localCratePath, err = loadLocalMetadata(localRoot, slug)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		repoPath = c.serviceRepoPath(slug)
-		metadataPath := path.Join(repoPath, metadataFile)
-		rawMetadata, err = c.getFile(ctx, metadataPath)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	crate, err := ParseROCrate(rawMetadata)
-	if err != nil {
-		return nil, err
-	}
-
-	tests, err := crate.AcceptanceTests()
+	repoPath, localCratePath, tests, err := c.loadAcceptanceTests(ctx, slug, localRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -137,6 +116,66 @@ func (c *Client) ValidateService(ctx context.Context, slug string, clusterCfg *c
 	}
 
 	return results, nil
+}
+
+// AcceptanceCommands renders the acceptance tests for the provided slug as runnable shell commands.
+func (c *Client) AcceptanceCommands(ctx context.Context, slug string, serviceNameOverride string, localRoot string) ([]AcceptanceCommandSet, error) {
+	if strings.TrimSpace(slug) == "" {
+		return nil, errors.New("service slug cannot be empty")
+	}
+
+	_, localCratePath, tests, err := c.loadAcceptanceTests(ctx, slug, localRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	sets := make([]AcceptanceCommandSet, 0, len(tests))
+	for _, test := range tests {
+		set := AcceptanceCommandSet{
+			Test:     test,
+			Commands: renderAcceptanceCommands(test, slug, serviceNameOverride, localCratePath),
+		}
+		sets = append(sets, set)
+	}
+
+	return sets, nil
+}
+
+func (c *Client) loadAcceptanceTests(ctx context.Context, slug string, localRoot string) (string, string, []AcceptanceTest, error) {
+
+	var (
+		repoPath       string
+		localCratePath string
+		rawMetadata    []byte
+		err            error
+	)
+
+	localRoot = strings.TrimSpace(localRoot)
+	if localRoot != "" {
+		rawMetadata, localCratePath, err = loadLocalMetadata(localRoot, slug)
+		if err != nil {
+			return "", "", nil, err
+		}
+	} else {
+		repoPath = c.serviceRepoPath(slug)
+		metadataPath := path.Join(repoPath, metadataFile)
+		rawMetadata, err = c.getFile(ctx, metadataPath)
+		if err != nil {
+			return "", "", nil, err
+		}
+	}
+
+	crate, err := ParseROCrate(rawMetadata)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	tests, err := crate.AcceptanceTests()
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	return repoPath, localCratePath, tests, nil
 }
 
 func (c *Client) runAcceptanceTest(ctx context.Context, repoPath, slug string, test AcceptanceTest, clusterCfg *cluster.Cluster, serviceNameOverride string, localCratePath string, svcCache map[string]*types.Service) AcceptanceResult {
@@ -191,6 +230,218 @@ func buildTestSupplyMap(test AcceptanceTest) map[string]TestInput {
 		supply[input.ID] = input
 	}
 	return supply
+}
+
+func renderAcceptanceCommands(test AcceptanceTest, slug string, serviceNameOverride string, localCratePath string) []string {
+	if len(test.Steps) == 0 {
+		return nil
+	}
+
+	supply := buildTestSupplyMap(test)
+	commands := make([]string, 0, len(test.Steps))
+	for _, step := range test.Steps {
+		parsed := step.ParsedCommand
+		if parsed == nil && strings.TrimSpace(step.Command) != "" {
+			tmp, err := parseAcceptanceCommand(step.Command)
+			if err == nil {
+				parsed = &tmp
+			}
+		}
+		if parsed == nil {
+			continue
+		}
+
+		serviceName := strings.TrimSpace(parsed.ServiceName)
+		if strings.TrimSpace(serviceNameOverride) != "" {
+			serviceName = strings.TrimSpace(serviceNameOverride)
+		}
+		if serviceName == "" {
+			serviceName = slug
+		}
+
+		stepSupply := mergeSupplyMaps(supply, step.Inputs)
+		if rendered := renderParsedCommand(*parsed, step, serviceName, stepSupply, localCratePath); rendered != "" {
+			commands = append(commands, rendered)
+		}
+	}
+	return commands
+}
+
+func renderParsedCommand(cmd parsedCommand, step AcceptanceStep, serviceName string, supply map[string]TestInput, localCratePath string) string {
+	switch cmd.Kind {
+	case stepCommandRun:
+		args := []string{"oscar-cli", "service", "run", serviceName}
+		switch cmd.RunDirective.Mode {
+		case inputModeFile:
+			args = append(args, "--file-input", resolveInputPath(cmd.RunDirective.Value, supply, localCratePath))
+		case inputModeText:
+			args = append(args, "--text-input", cmd.RunDirective.Value)
+		default:
+			return ""
+		}
+		return shellJoin(args)
+	case stepCommandPutFile:
+		args := []string{"oscar-cli", "service", "put-file", serviceName}
+		if strings.TrimSpace(cmd.Provider) != "" {
+			args = append(args, cmd.Provider)
+		}
+		args = append(args, resolveInputPath(cmd.LocalPath, supply, localCratePath))
+		if strings.TrimSpace(cmd.RemotePath) != "" {
+			args = append(args, cmd.RemotePath)
+		}
+		return shellJoin(args)
+	case stepCommandGetFile:
+		args := []string{"oscar-cli", "service", "get-file", serviceName}
+		if strings.TrimSpace(cmd.Provider) != "" {
+			args = append(args, cmd.Provider)
+		}
+		if strings.TrimSpace(cmd.RemotePath) != "" {
+			args = append(args, cmd.RemotePath)
+		}
+		if cmd.LatestRequested {
+			destination := cmd.LatestValue
+			if strings.TrimSpace(destination) == "" {
+				destination = "./downloads"
+			}
+			args = append(args, "--download-latest-into", destination)
+		} else if strings.TrimSpace(cmd.LocalPath) != "" {
+			args = append(args, cmd.LocalPath)
+		}
+		return shellJoin(args)
+	case stepCommandWait:
+		if cmd.WaitDuration <= 0 {
+			return ""
+		}
+		return shellJoin([]string{"sleep", strconv.Itoa(int(cmd.WaitDuration.Round(time.Second).Seconds()))})
+	case stepCommandHTTP:
+		return renderHTTPCurlCommand(cmd, step, serviceName, supply, localCratePath)
+	default:
+		return ""
+	}
+}
+
+func renderHTTPCurlCommand(cmd parsedCommand, step AcceptanceStep, serviceName string, supply map[string]TestInput, localCratePath string) string {
+	args := []string{"curl", "-sS"}
+	method := strings.ToUpper(strings.TrimSpace(cmd.HTTPMethod))
+	if method == "" {
+		method = http.MethodGet
+	}
+	if method != http.MethodGet {
+		args = append(args, "-X", method)
+	}
+	if cmd.HTTPUseServiceAuth {
+		args = append(args, "-u", fmt.Sprintf("%s:${SERVICE_TOKEN}", serviceName))
+	}
+	if strings.TrimSpace(cmd.HTTPAccept) != "" {
+		args = append(args, "-H", "Accept: "+cmd.HTTPAccept)
+	}
+	if len(step.Inputs) > 0 {
+		fieldName := strings.TrimSpace(cmd.HTTPFormField)
+		if fieldName == "" {
+			fieldName = "file"
+		}
+		for _, input := range step.Inputs {
+			path := resolveInputPath(input.ID, supply, localCratePath)
+			formValue := fmt.Sprintf("%s=@%s", fieldName, path)
+			if strings.TrimSpace(input.EncodingFormat) != "" {
+				formValue += ";type=" + input.EncodingFormat
+			}
+			args = append(args, "-F", formValue)
+		}
+	}
+	if outputPath := suggestedOutputPath(step); outputPath != "" {
+		args = append(args, "--output", outputPath)
+	}
+	requestPath := strings.TrimSpace(cmd.HTTPPath)
+	if !strings.HasPrefix(requestPath, "/") {
+		requestPath = "/" + requestPath
+	}
+	args = append(args, "${OSCAR_ENDPOINT%/}/system/services/"+serviceName+"/exposed"+requestPath)
+	return shellJoin(args)
+}
+
+func suggestedOutputPath(step AcceptanceStep) string {
+	for _, mt := range step.ExpectedMedia {
+		switch normalizeMediaType(mt) {
+		case "application/zip":
+			return "./acceptance-output.zip"
+		case "image/png":
+			return "./acceptance-output.png"
+		case "image/jpeg":
+			return "./acceptance-output.jpg"
+		}
+	}
+	return ""
+}
+
+func resolveInputPath(value string, supply map[string]TestInput, localCratePath string) string {
+	if input, ok := supply[value]; ok {
+		if path := localInputPath(input, localCratePath); path != "" {
+			return path
+		}
+		if strings.TrimSpace(input.URL) != "" {
+			return input.URL
+		}
+		if strings.TrimSpace(input.ID) != "" {
+			return "./" + filepath.Base(input.ID)
+		}
+	}
+	if path := localInputPath(TestInput{ID: value}, localCratePath); path != "" {
+		return path
+	}
+	if strings.TrimSpace(value) == "" {
+		return "./input"
+	}
+	return "./" + filepath.Base(value)
+}
+
+func localInputPath(input TestInput, localCratePath string) string {
+	if strings.TrimSpace(localCratePath) == "" {
+		return ""
+	}
+	candidates := []string{input.ID, input.URL}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || isAbsoluteURL(candidate) {
+			continue
+		}
+		clean := filepath.Clean(candidate)
+		if clean == "." || strings.HasPrefix(clean, "..") {
+			continue
+		}
+		full := filepath.Join(localCratePath, clean)
+		if info, err := os.Stat(full); err == nil && !info.IsDir() {
+			if abs, err := filepath.Abs(full); err == nil {
+				return abs
+			}
+			return full
+		}
+	}
+	return ""
+}
+
+func shellJoin(args []string) string {
+	parts := make([]string, 0, len(args))
+	for _, arg := range args {
+		if strings.TrimSpace(arg) == "" {
+			continue
+		}
+		parts = append(parts, shellQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.Contains(value, "${") {
+		return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+	}
+	if strings.ContainsAny(value, " \t\n'\"$;&|<>*?()[]{}!") {
+		return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+	}
+	return value
 }
 
 func (c *Client) executeAcceptanceStep(ctx context.Context, repoPath, slug string, test AcceptanceTest, step AcceptanceStep, baseSupply map[string]TestInput, clusterCfg *cluster.Cluster, serviceNameOverride string, localCratePath string, svcCache map[string]*types.Service, tempDir string) AcceptanceStepResult {

--- a/pkg/hub/validate.go
+++ b/pkg/hub/validate.go
@@ -1,18 +1,24 @@
 package hub
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -52,21 +58,28 @@ const (
 	stepCommandPutFile
 	stepCommandGetFile
 	stepCommandWait
+	stepCommandHTTP
 )
 
 type parsedCommand struct {
-	Kind            stepCommandKind
-	ServiceName     string
-	RunDirective    inputDirective
-	Provider        string
-	LocalPath       string
-	RemotePath      string
-	RemoteProvided  bool
-	LocalProvided   bool
-	LatestRequested bool
-	LatestValue     string
-	NoProgress      bool
-	WaitDuration    time.Duration
+	Kind               stepCommandKind
+	ServiceName        string
+	RunDirective       inputDirective
+	Provider           string
+	LocalPath          string
+	RemotePath         string
+	RemoteProvided     bool
+	LocalProvided      bool
+	LatestRequested    bool
+	LatestValue        string
+	NoProgress         bool
+	WaitDuration       time.Duration
+	HTTPMethod         string
+	HTTPPath           string
+	HTTPAccept         string
+	HTTPFormField      string
+	HTTPUseServiceAuth bool
+	HTTPExpectStatus   int
 }
 
 // ValidateService downloads the RO-Crate metadata for the provided slug, runs its acceptance tests against the cluster and returns the aggregated results.
@@ -379,12 +392,99 @@ func (c *Client) executeAcceptanceStep(ctx context.Context, repoPath, slug strin
 			result.Passed = true
 			result.Output = fmt.Sprintf("Waited %s", parsed.WaitDuration)
 		}
+	case stepCommandHTTP:
+		svc, err := getServiceDefinition(clusterCfg, serviceName, svcCache)
+		if err != nil {
+			result.Err = err
+			return result
+		}
+
+		payloads, err := resolveHTTPPayloads(ctx, supply, step.Inputs, c, repoPath, localCratePath)
+		if err != nil {
+			result.Err = err
+			return result
+		}
+
+		responseData, responseMedia, statusCode, err := invokeExposedHTTP(clusterCfg, svc, serviceName, *parsed, payloads)
+		if err != nil {
+			result.Err = err
+			return result
+		}
+
+		expectedStatus := parsed.HTTPExpectStatus
+		if expectedStatus == 0 {
+			expectedStatus = http.StatusOK
+		}
+		if statusCode != expectedStatus {
+			result.Passed = false
+			result.Details = fmt.Sprintf("expected HTTP status %d, got %d", expectedStatus, statusCode)
+			result.Output = fmt.Sprintf("HTTP %d", statusCode)
+			return result
+		}
+
+		if len(step.ExpectedMedia) > 0 {
+			detected := firstMatchingMediaType(responseMedia, http.DetectContentType(responseData))
+			if !mediaTypeMatches(detected, step.ExpectedMedia) {
+				result.Passed = false
+				result.Details = fmt.Sprintf("expected media type %s, got %s", strings.Join(step.ExpectedMedia, ", "), detected)
+				result.Output = fmt.Sprintf("HTTP %d, media type: %s", statusCode, detected)
+				return result
+			}
+
+			if normalizeMediaType(detected) == "application/zip" {
+				if err := validateZIPPayload(responseData); err != nil {
+					result.Passed = false
+					result.Details = err.Error()
+					result.Output = fmt.Sprintf("HTTP %d, media type: %s", statusCode, detected)
+					return result
+				}
+			}
+
+			result.Passed = true
+			result.Output = fmt.Sprintf("HTTP %d, media type: %s, bytes: %d", statusCode, detected, len(responseData))
+			return result
+		}
+
+		output := string(responseData)
+		result.Passed, result.Details = evaluateExpectation(step.ExpectedSubstring, output)
+		result.Output = previewOutput(output)
 	default:
 		result.Err = fmt.Errorf("unsupported command for step %s: %s", step.ID, step.Command)
 		return result
 	}
 
 	return result
+}
+
+type httpPayload struct {
+	Name        string
+	Content     []byte
+	ContentType string
+}
+
+func resolveHTTPPayloads(ctx context.Context, supply map[string]TestInput, stepInputs []TestInput, client *Client, repoPath, localCratePath string) ([]httpPayload, error) {
+	if len(stepInputs) == 0 {
+		return nil, errCommandMissingInput
+	}
+
+	payloads := make([]httpPayload, 0, len(stepInputs))
+	for _, input := range stepInputs {
+		content, err := fetchSupplyContent(ctx, client, repoPath, localCratePath, input)
+		if err != nil {
+			return nil, err
+		}
+
+		name := strings.TrimSpace(input.ID)
+		if name == "" {
+			name = "input"
+		}
+		payloads = append(payloads, httpPayload{
+			Name:        filepath.Base(name),
+			Content:     content,
+			ContentType: strings.TrimSpace(input.EncodingFormat),
+		})
+	}
+	return payloads, nil
 }
 
 func mergeSupplyMaps(base map[string]TestInput, stepInputs []TestInput) map[string]TestInput {
@@ -749,6 +849,8 @@ func parseAcceptanceCommand(command string) (parsedCommand, error) {
 		return parseServicePutFile(rest)
 	case "get-file":
 		return parseServiceGetFile(rest)
+	case "http":
+		return parseServiceHTTP(rest)
 	default:
 		return parsedCommand{}, fmt.Errorf("unsupported service subcommand %q", action)
 	}
@@ -867,6 +969,89 @@ func parseServiceGetFile(args []string) (parsedCommand, error) {
 	parsed.LocalProvided = localProvided
 
 	return parsed, nil
+}
+
+func parseServiceHTTP(args []string) (parsedCommand, error) {
+	parsed := parsedCommand{
+		Kind:               stepCommandHTTP,
+		HTTPMethod:         http.MethodGet,
+		HTTPUseServiceAuth: true,
+		HTTPExpectStatus:   http.StatusOK,
+	}
+	if len(args) == 0 {
+		return parsedCommand{}, fmt.Errorf("service http requires SERVICE_NAME argument")
+	}
+
+	positional := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--method":
+			if i+1 >= len(args) {
+				return parsedCommand{}, fmt.Errorf("flag %s missing value", arg)
+			}
+			parsed.HTTPMethod = strings.ToUpper(strings.TrimSpace(args[i+1]))
+			i++
+		case "--path":
+			if i+1 >= len(args) {
+				return parsedCommand{}, fmt.Errorf("flag %s missing value", arg)
+			}
+			parsed.HTTPPath = strings.TrimSpace(args[i+1])
+			i++
+		case "--accept":
+			if i+1 >= len(args) {
+				return parsedCommand{}, fmt.Errorf("flag %s missing value", arg)
+			}
+			parsed.HTTPAccept = strings.TrimSpace(args[i+1])
+			i++
+		case "--form-field":
+			if i+1 >= len(args) {
+				return parsedCommand{}, fmt.Errorf("flag %s missing value", arg)
+			}
+			parsed.HTTPFormField = strings.TrimSpace(args[i+1])
+			i++
+		case "--no-service-auth":
+			parsed.HTTPUseServiceAuth = false
+		case "--status":
+			if i+1 >= len(args) {
+				return parsedCommand{}, fmt.Errorf("flag %s missing value", arg)
+			}
+			status, err := parsePositiveInt(args[i+1])
+			if err != nil {
+				return parsedCommand{}, fmt.Errorf("invalid status code %q", args[i+1])
+			}
+			parsed.HTTPExpectStatus = status
+			i++
+		default:
+			if strings.HasPrefix(arg, "--") {
+				return parsedCommand{}, fmt.Errorf("unsupported flag %q in http command", arg)
+			}
+			positional = append(positional, arg)
+		}
+	}
+
+	if len(positional) == 0 {
+		return parsedCommand{}, fmt.Errorf("service name cannot be empty")
+	}
+	parsed.ServiceName = positional[0]
+	if parsed.HTTPPath == "" {
+		return parsedCommand{}, fmt.Errorf("service http requires --path")
+	}
+	if parsed.HTTPMethod == "" {
+		parsed.HTTPMethod = http.MethodGet
+	}
+	return parsed, nil
+}
+
+func parsePositiveInt(raw string) (int, error) {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, err
+	}
+	if value <= 0 {
+		return 0, fmt.Errorf("must be positive")
+	}
+	return value, nil
 }
 
 func parsePutFileCommandArgs(args []string) (provider, localFile, remoteFile string, remoteProvided bool, err error) {
@@ -1029,6 +1214,133 @@ func invokeServiceWithContent(clusterCfg *cluster.Cluster, serviceName string, p
 	}
 	// Fallback to raw response when it is not base64 encoded.
 	return raw, nil
+}
+
+func invokeExposedHTTP(clusterCfg *cluster.Cluster, svc *types.Service, serviceName string, cmd parsedCommand, payloads []httpPayload) ([]byte, string, int, error) {
+	if clusterCfg == nil {
+		return nil, "", 0, errors.New("cluster configuration is required")
+	}
+	if svc == nil {
+		return nil, "", 0, errors.New("service definition is required")
+	}
+
+	baseURL, err := url.Parse(clusterCfg.Endpoint)
+	if err != nil {
+		return nil, "", 0, cluster.ErrParsingEndpoint
+	}
+
+	requestPath := strings.TrimSpace(cmd.HTTPPath)
+	if requestPath == "" {
+		return nil, "", 0, errors.New("http path cannot be empty")
+	}
+	hasTrailingSlash := strings.HasSuffix(requestPath, "/")
+	if !strings.HasPrefix(requestPath, "/") {
+		requestPath = "/" + requestPath
+	}
+	baseURL.Path = path.Join(baseURL.Path, "/system/services", serviceName, "exposed")
+	baseURL.Path = path.Join(baseURL.Path, requestPath)
+	if hasTrailingSlash && !strings.HasSuffix(baseURL.Path, "/") {
+		baseURL.Path += "/"
+	}
+
+	var body io.Reader
+	contentType := ""
+	method := strings.ToUpper(strings.TrimSpace(cmd.HTTPMethod))
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	if len(payloads) > 0 {
+		var buffer bytes.Buffer
+		writer := multipart.NewWriter(&buffer)
+		fieldName := strings.TrimSpace(cmd.HTTPFormField)
+		if fieldName == "" {
+			fieldName = "file"
+		}
+		for _, payload := range payloads {
+			header := textproto.MIMEHeader{}
+			header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, escapeQuotes(fieldName), escapeQuotes(payload.Name)))
+			partType := strings.TrimSpace(payload.ContentType)
+			if partType == "" {
+				partType = mime.TypeByExtension(filepath.Ext(payload.Name))
+			}
+			if partType == "" {
+				partType = "application/octet-stream"
+			}
+			header.Set("Content-Type", partType)
+			part, err := writer.CreatePart(header)
+			if err != nil {
+				return nil, "", 0, fmt.Errorf("creating multipart field: %w", err)
+			}
+			if _, err := part.Write(payload.Content); err != nil {
+				return nil, "", 0, fmt.Errorf("writing multipart content: %w", err)
+			}
+		}
+		if err := writer.Close(); err != nil {
+			return nil, "", 0, fmt.Errorf("closing multipart body: %w", err)
+		}
+		body = &buffer
+		contentType = writer.FormDataContentType()
+	}
+
+	req, err := http.NewRequest(method, baseURL.String(), body)
+	if err != nil {
+		return nil, "", 0, cluster.ErrMakingRequest
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if accept := strings.TrimSpace(cmd.HTTPAccept); accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	if cmd.HTTPUseServiceAuth && svc.Expose.SetAuth {
+		req.SetBasicAuth(serviceName, svc.Token)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: !clusterCfg.SSLVerify},
+		},
+		Timeout: 30 * time.Second,
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, "", 0, cluster.ErrSendingRequest
+	}
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("reading http response: %w", err)
+	}
+
+	return data, res.Header.Get("Content-Type"), res.StatusCode, nil
+}
+
+func firstMatchingMediaType(values ...string) string {
+	for _, value := range values {
+		if normalized := normalizeMediaType(value); normalized != "" {
+			return normalized
+		}
+	}
+	return ""
+}
+
+func validateZIPPayload(data []byte) error {
+	readerAt := bytes.NewReader(data)
+	archive, err := zip.NewReader(readerAt, int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("response is not a valid zip archive: %w", err)
+	}
+	if len(archive.File) == 0 {
+		return errors.New("zip archive is empty")
+	}
+	return nil
+}
+
+func escapeQuotes(value string) string {
+	replacer := strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+	return replacer.Replace(value)
 }
 
 func previewOutput(output string) string {

--- a/pkg/hub/validate_test.go
+++ b/pkg/hub/validate_test.go
@@ -3,11 +3,14 @@ package hub
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"io"
 	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -217,6 +220,85 @@ func TestInvokeExposedHTTPUsesServiceAuthAndMultipart(t *testing.T) {
 	}
 	if err := validateZIPPayload(data); err != nil {
 		t.Fatalf("validateZIPPayload returned error: %v", err)
+	}
+}
+
+func TestAcceptanceCommandsRenderHTTPAndLocalPaths(t *testing.T) {
+	dir := t.TempDir()
+	crateDir := filepath.Join(dir, "posenet-tf")
+	if err := os.MkdirAll(crateDir, 0o755); err != nil {
+		t.Fatalf("creating crate dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(crateDir, "001.jpg"), []byte("jpeg"), 0o600); err != nil {
+		t.Fatalf("writing sample image: %v", err)
+	}
+	raw := `{
+	  "@graph": [
+	    { "@id": "./", "subjectOf": [{ "@id": "#acceptance" }] },
+	    { "@id": "001.jpg", "@type": ["File","ImageObject"], "encodingFormat": "image/jpeg" },
+	    { "@id": "#expected-zip", "@type": ["File"], "encodingFormat": "application/zip" },
+	    {
+	      "@id": "#acceptance",
+	      "@type": "HowTo",
+	      "name": "HTTP acceptance",
+	      "step": [{ "@id": "#step-http" }]
+	    },
+	    {
+	      "@id": "#step-http",
+	      "@type": "HowToStep",
+	      "position": 1,
+	      "potentialAction": { "@id": "#action-http" }
+	    },
+	    {
+	      "@id": "#action-http",
+	      "@type": "ConsumeAction",
+	      "name": "http-request",
+	      "object": { "@id": "001.jpg" },
+	      "result": { "@id": "#expected-zip" },
+	      "additionalProperty": [
+	        { "@id": "#prop-method" },
+	        { "@id": "#prop-path" },
+	        { "@id": "#prop-accept" },
+	        { "@id": "#prop-form-field" }
+	      ]
+	    },
+	    { "@id": "#prop-method", "@type": "PropertyValue", "propertyID": "method", "value": "POST" },
+	    { "@id": "#prop-path", "@type": "PropertyValue", "propertyID": "path", "value": "/v2/models/posenetclas/predict/" },
+	    { "@id": "#prop-accept", "@type": "PropertyValue", "propertyID": "accept", "value": "application/zip" },
+	    { "@id": "#prop-form-field", "@type": "PropertyValue", "propertyID": "formField", "value": "data" }
+	  ]
+	}`
+	if err := os.WriteFile(filepath.Join(crateDir, "ro-crate-metadata.json"), []byte(raw), 0o600); err != nil {
+		t.Fatalf("writing ro-crate: %v", err)
+	}
+
+	client := NewClient()
+	sets, err := client.AcceptanceCommands(context.Background(), "posenet-tf", "body-pose", dir)
+	if err != nil {
+		t.Fatalf("AcceptanceCommands returned error: %v", err)
+	}
+	if len(sets) != 1 {
+		t.Fatalf("expected 1 command set, got %d", len(sets))
+	}
+	if len(sets[0].Commands) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(sets[0].Commands))
+	}
+	command := sets[0].Commands[0]
+	if !strings.Contains(command, "curl") {
+		t.Fatalf("expected curl command, got %q", command)
+	}
+	if !strings.Contains(command, "body-pose:${SERVICE_TOKEN}") {
+		t.Fatalf("expected service auth placeholder, got %q", command)
+	}
+	if !strings.Contains(command, "/system/services/body-pose/exposed/v2/models/posenetclas/predict/") {
+		t.Fatalf("expected exposed path, got %q", command)
+	}
+	if !strings.Contains(command, "--output './acceptance-output.zip'") && !strings.Contains(command, "--output ./acceptance-output.zip") {
+		t.Fatalf("expected output redirection, got %q", command)
+	}
+	absImage, _ := filepath.Abs(filepath.Join(crateDir, "001.jpg"))
+	if !strings.Contains(command, absImage) {
+		t.Fatalf("expected absolute sample image path, got %q", command)
 	}
 }
 

--- a/pkg/hub/validate_test.go
+++ b/pkg/hub/validate_test.go
@@ -1,9 +1,19 @@
 package hub
 
 import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/grycap/oscar-cli/pkg/cluster"
 	"github.com/grycap/oscar-cli/pkg/storage"
+	"github.com/grycap/oscar/v3/pkg/types"
 )
 
 func TestParseAcceptanceCommandRun(t *testing.T) {
@@ -77,4 +87,157 @@ func TestParseAcceptanceCommandGetFileLatest(t *testing.T) {
 	if cmd.LocalProvided {
 		t.Fatalf("expected LocalProvided to be false when destination derived from flag")
 	}
+}
+
+func TestParseAcceptanceCommandHTTP(t *testing.T) {
+	cmd, err := parseAcceptanceCommand("oscar-cli service http demo --method POST --path /v2/models/demo/predict/ --accept application/zip --form-field data --status 200")
+	if err != nil {
+		t.Fatalf("parseAcceptanceCommand returned error: %v", err)
+	}
+
+	if cmd.Kind != stepCommandHTTP {
+		t.Fatalf("expected stepCommandHTTP, got %v", cmd.Kind)
+	}
+	if cmd.ServiceName != "demo" {
+		t.Fatalf("expected service name demo, got %s", cmd.ServiceName)
+	}
+	if cmd.HTTPMethod != http.MethodPost {
+		t.Fatalf("expected POST method, got %s", cmd.HTTPMethod)
+	}
+	if cmd.HTTPPath != "/v2/models/demo/predict/" {
+		t.Fatalf("unexpected http path %q", cmd.HTTPPath)
+	}
+	if cmd.HTTPAccept != "application/zip" {
+		t.Fatalf("unexpected accept header %q", cmd.HTTPAccept)
+	}
+	if cmd.HTTPFormField != "data" {
+		t.Fatalf("unexpected form field %q", cmd.HTTPFormField)
+	}
+	if cmd.HTTPExpectStatus != http.StatusOK {
+		t.Fatalf("unexpected expected status %d", cmd.HTTPExpectStatus)
+	}
+	if !cmd.HTTPUseServiceAuth {
+		t.Fatalf("expected service auth to be enabled by default")
+	}
+}
+
+func TestInvokeExposedHTTPUsesServiceAuthAndMultipart(t *testing.T) {
+	const (
+		serviceName  = "demo"
+		serviceToken = "svc-token"
+	)
+
+	zipPayload := buildTestZIP(t)
+	var seenAuthHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST request, got %s", r.Method)
+		}
+		if r.URL.Path != "/system/services/demo/exposed/v2/models/demo/predict/" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok {
+			t.Fatalf("expected basic auth header")
+		}
+		seenAuthHeader = r.Header.Get("Authorization")
+		if user != serviceName || pass != serviceToken {
+			t.Fatalf("unexpected credentials %s:%s", user, pass)
+		}
+		if got := r.Header.Get("Accept"); got != "application/zip" {
+			t.Fatalf("unexpected accept header %q", got)
+		}
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Fatalf("parsing content type: %v", err)
+		}
+		if mediaType != "multipart/form-data" {
+			t.Fatalf("unexpected media type %q", mediaType)
+		}
+		reader := multipartReader(t, r.Body, params["boundary"])
+		part, err := reader.NextPart()
+		if err != nil {
+			t.Fatalf("reading multipart part: %v", err)
+		}
+		if part.FormName() != "data" {
+			t.Fatalf("unexpected form field %q", part.FormName())
+		}
+		if part.FileName() != "001.jpg" {
+			t.Fatalf("unexpected file name %q", part.FileName())
+		}
+		if got := part.Header.Get("Content-Type"); got != "image/jpeg" {
+			t.Fatalf("unexpected part content type %q", got)
+		}
+		body, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("reading part body: %v", err)
+		}
+		if string(body) != "image-bytes" {
+			t.Fatalf("unexpected multipart body %q", string(body))
+		}
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(zipPayload); err != nil {
+			t.Fatalf("writing response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	data, mediaType, status, err := invokeExposedHTTP(
+		&cluster.Cluster{Endpoint: server.URL, SSLVerify: true},
+		&types.Service{Name: serviceName, Token: serviceToken, Expose: types.Expose{SetAuth: true}},
+		serviceName,
+		parsedCommand{
+			Kind:               stepCommandHTTP,
+			HTTPMethod:         http.MethodPost,
+			HTTPPath:           "/v2/models/demo/predict/",
+			HTTPAccept:         "application/zip",
+			HTTPFormField:      "data",
+			HTTPUseServiceAuth: true,
+			HTTPExpectStatus:   http.StatusOK,
+		},
+		[]httpPayload{{Name: "001.jpg", Content: []byte("image-bytes"), ContentType: "image/jpeg"}},
+	)
+	if err != nil {
+		t.Fatalf("invokeExposedHTTP returned error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", status)
+	}
+	if mediaType != "application/zip" {
+		t.Fatalf("unexpected response media type %q", mediaType)
+	}
+	if !bytes.Equal(data, zipPayload) {
+		t.Fatalf("unexpected response payload")
+	}
+	if !strings.HasPrefix(seenAuthHeader, "Basic ") {
+		t.Fatalf("expected basic authorization header, got %q", seenAuthHeader)
+	}
+	if err := validateZIPPayload(data); err != nil {
+		t.Fatalf("validateZIPPayload returned error: %v", err)
+	}
+}
+
+func multipartReader(t *testing.T, body io.Reader, boundary string) *multipart.Reader {
+	t.Helper()
+	return multipart.NewReader(body, boundary)
+}
+
+func buildTestZIP(t *testing.T) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	entry, err := writer.Create("result.txt")
+	if err != nil {
+		t.Fatalf("creating zip entry: %v", err)
+	}
+	if _, err := entry.Write([]byte("ok")); err != nil {
+		t.Fatalf("writing zip entry: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("closing zip writer: %v", err)
+	}
+	return buffer.Bytes()
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -282,8 +282,6 @@ func RunService(c *cluster.Cluster, name string, token string, endpoint string, 
 	}
 	runServiceURL.Path = path.Join(runServiceURL.Path, runPath, name)
 	// Make the request
-	fmt.Println("Invoking service at:", runServiceURL.String())
-	fmt.Println("Invoking service at:", client.Transport)
 	req, err := http.NewRequest(http.MethodPost, runServiceURL.String(), input)
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)


### PR DESCRIPTION
This PR extends oscar-cli hub validate to better support acceptance tests for exposed services.

In oscar-cli, hub validate now understands a structured exposed HTTP acceptance step for RO-Crate metadata. The validator can execute multipart POST requests against /system/services/<name>/exposed/..., apply service Basic Auth with the OSCAR service token when required, and validate response status and media type, including ZIP payload checks. A new print-only mode, --print-acceptance-commands, renders the equivalent shell commands for each acceptance step, including the selected cluster endpoint and a command to obtain the service token from oscar-cli service get.