### PR TITLE
fix: enhance version command to display build info version

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,3 +1,19 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,23 +1,8 @@
-/*
-Copyright (C) GRyCAP - I3M - UPV
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -30,8 +15,11 @@ var (
 )
 
 func versionFunc(cmd *cobra.Command, args []string) {
+	info, ok := debug.ReadBuildInfo()
 	if Version != "" {
 		fmt.Println("version:", Version)
+	} else if ok && info.Main.Version != "" {
+		fmt.Println("version:", info.Main.Version)
 	} else {
 		fmt.Println("version: devel")
 	}


### PR DESCRIPTION
Fix the empty `oscar-cli version` when using `go install`

> Tested in the fork `https://github.com/rk181/oscar-cli` with `go install github.com/rk181/oscar-cli@latest`