### PR TITLE
feat: TUI update with quotas, deployment, command palette, search, volumes, and buckets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,479 @@
+# oscar-cli TUI — Agent Context
+
+## Project Overview
+oscar-cli is a Go CLI tool with a TUI mode (`--interactive`). The TUI is built with [tview](https://github.com/rivo/tview) and [tcell](https://github.com/gdamore/tcell/v2). It displays Oscar clusters (left panel), a main table (services/buckets/volumes/logs), and a details panel (right). A status bar at the bottom shows prompts and a status line.
+
+## Architecture
+- **Entry point**: `Run(ctx, conf)` in `pkg/tui/app.go`
+- **State struct**: `uiState` in `pkg/tui/state.go`
+- **Modes**: `modeServices`, `modeBuckets`, `modeLogs`, `modeVolumes` (iota in state.go)
+- **Panels**: `clusterList` (left), `serviceTable` (center), `detailsView` (right), `bucketObjectsTable` (sub-table in buckets mode), `statusContainer` (bottom bar)
+- **Concurrency**: All UI reads/writes from goroutines use `s.mutex.Lock()`. Async work uses `defer/recover` for panic safety. UI updates use `s.queueUpdate(fn)`. Input handling is serialized via `atomic.CompareAndSwapInt32(&s.inputHandling, 0, 1)`.
+- **SDK**: Oscar API types come from `github.com/grycap/oscar/v4/pkg/types`. Cluster config from `github.com/grycap/oscar-cli/pkg/cluster`. Service operations from `github.com/grycap/oscar-cli/pkg/service`. Storage from `github.com/grycap/oscar-cli/pkg/storage`.
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `pkg/tui/app.go` | Main Run function, handleInput, all async show-* methods, quota wizard (5 steps), deploy status/logs |
+| `pkg/tui/state.go` | State struct, panel modes, constants, legendText, statusHelpText |
+| `pkg/tui/commands.go` | Command palette (`:`): registry, autocomplete, executeCommand |
+| `pkg/tui/search.go` | Search (`/`): initiateSearch (auto-detects target based on focus+mode), show/hide/handleSearchInput |
+| `pkg/tui/dialogs.go` | `legendTextForMode(mode)`, `toggleLegend`, `showLegendUnlocked`, `requestDeletion` |
+| `pkg/tui/formatters.go` | formatQuota, formatDeploymentStatus, formatDeploymentLogs, formatMetricsSummary, formatServiceDetails, formatVolumeDetails, formatBucketDetails, formatClusterConfig, formatServiceLogs |
+| `pkg/tui/buckets_view.go` | Bucket mode rendering, promptCreateBucket |
+| `pkg/tui/volumes_view.go` | Volume mode rendering, promptCreateVolume |
+| `pkg/tui/services_view.go` | Services mode rendering |
+| `pkg/tui/logs_view.go` | Logs mode rendering |
+| `pkg/cluster/quotas.go` | GetQuota(cfg, userID), UpdateQuota(cfg, userID, cpu, mem, volUpdate) |
+| `pkg/service/deployment.go` | GetDeploymentStatus(cfg, name), GetDeploymentLogs(cfg, name) |
+
+## Key Bindings (as of May 2026)
+
+### General
+- `q` — Quit
+- `r` — Refresh current view
+- `i` — Show cluster info
+- `e` — Show cluster status
+- `m` — Show cluster metrics
+- `w` — Configure auto-refresh
+- `b` — Switch to buckets view
+- `s` — Switch to services view
+- `v` — Switch to volumes view
+- `f` — Focus details panel (toggle)
+- `?` — Toggle help/legend (mode-specific keybindings shown)
+- `:` — Open command palette
+- `/` — Search (scoped to current mode)
+- `←/→/Tab` — Switch pane
+- `↑/↓` — Move selection
+
+### Services mode
+- `d/Del` — Delete selected service
+- `l` — Open logs panel
+- `g` — Get quota (if basic auth, prompts userID; otherwise fetches directly)
+- `k` — Update quota (5-step wizard, only for basic auth)
+- `t` — Show deployment status
+- `h` — Show deployment logs
+- `Enter` — Focus service details → logs
+
+### Volumes mode
+- `c` — Create volume
+- `d/Del` — Delete volume
+
+### Buckets mode
+- `c` — Create bucket
+- `d/Del` — Delete bucket
+- `Enter` — Focus bucket objects
+- `u` — Upload file (from bucket objects view)
+- `o` — Reload bucket objects
+- `n/p` — Next/previous page
+- `a` — Load all objects
+
+### Logs mode
+- `l` — Open logs panel
+- `d/Del` — Delete log
+
+## Command Palette (`:`)
+
+- Shows autocomplete with all commands sorted alphabetically.
+- Blank entry (empty string) at top of suggestions when input is empty — pressing Enter on empty input closes the palette without executing.
+- Backspace on empty input dismisses the palette.
+- Enter with text executes the best match.
+- User types with spaces, internal names use dots (e.g. "quota update" → `quota.update`). `executeCommand` normalizes.
+
+### Registered Commands
+```
+help, refresh, cluster.info, cluster.status, cluster.metrics,
+quota.get, quota.update, deploy.status, deploy.logs,
+search, services, volumes, volume.create,
+buckets, bucket.create
+```
+
+## Search (`/`)
+
+`initiateSearch(ctx)` auto-detects target:
+1. Based on focused element (clusterList → clusters, serviceTable → depends on mode, detailsView → details, bucketObjectsTable → buckets)
+2. If target is clusters but mode is buckets/volumes/services, overrides to search that mode's data
+3. Fallback: clusters if still none
+
+Search targets: `searchTargetNone`, `searchTargetClusters`, `searchTargetServices`, `searchTargetLogs`, `searchTargetBuckets`, `searchTargetVolumes`, `searchTargetDetails`
+
+## Quota System
+
+- **Get**: `cluster.GetQuota(cfg, userID)` → GET `{endpoint}/system/quotas/user/{userID}`
+  - If cluster has `auth_user`/`auth_password` (basic auth): prompts for userID first. Empty userID shows error.
+  - Otherwise: fetches directly with empty userID.
+  - Displayed via `formatQuota(name, quota)` showing resources (sorted, color-coded) and volume quotas.
+- **Update**: `cluster.UpdateQuota(cfg, userID, cpu, mem, volUpdate)` → PUT `{endpoint}/system/quotas/user/{userID}`
+  - Only available for basic auth clusters.
+  - `promptUpdateQuota()` enters a 5-step wizard (userID → CPU → Memory → Volume Disk → Volume Count).
+  - Each step input has `SetInputCapture` for Backspace → previous step.
+  - Backspace on step 0 (userID) dismisses wizard.
+  - `VolumeQuotaUpdate` struct with `Disk`, `Volumes`, `MaxDiskperVolume`, `MinDiskperVolume` (strings, omitempty).
+  - If both volume disk and count are empty, `volUpdate` param is nil.
+  - Also accessible via command palette `quota.update` with inline args: `quota update user cpu mem vol-disk vol-count` (no args → interactive wizard).
+
+## Deploy Status/Logs
+
+- **Status**: `service.GetDeploymentStatus(cfg, name)` → GET `{endpoint}/.../{name}/deployment`
+  - Formatted by `formatDeploymentStatus(name, ds)` showing state (color-coded: green=yellow/red/blue), reason, last transition time, instances.
+  - Guard nil `*metav1.Time` before formatting.
+- **Logs**: `service.GetDeploymentLogs(cfg, name)` → GET `{endpoint}/.../{name}/deployment/logs`
+  - Formatted by `formatDeploymentLogs(dl)` showing service name, available flag, message, entries.
+
+## Important Patterns
+
+### Adding a new keyboard shortcut
+1. Add the case in `handleInput` (app.go ~line 556-741).
+2. Update `legendTextForMode(mode)` in dialogs.go and `statusHelpText` in state.go (if global) or per-mode string.
+3. Add guard check in input handling chain (e.g. `if s.somePromptVisible` before the switch).
+
+### Adding a new command palette command
+1. Add a `registerCommand(...)` call in `initCommands()` (commands.go ~line 27-118).
+2. Register alphabetically within the file.
+
+### Adding a new prompt/wizard
+1. Add visible flag and saved-focus field to `uiState` in state.go.
+2. Add guard in `handleInput` so the prompt intercepts keys before global bindings.
+3. Create `promptShowXxx()` with `tview.NewInputField()`, `SetDoneFunc`, `SetInputCapture`.
+4. Create `hideXxx()` that restores focus and clears container.
+5. Optionally add Backspace-on-empty handling in `handleInput` at the `tcell.KeyBackspace` case.
+
+### Prompt visibility guard order (in handleInput, app.go)
+```
+searchVisible → autoRefreshPromptVisible → createVolumePromptVisible →
+createBucketPromptVisible → putFilePromptVisible → quotaPromptVisible →
+updateQuotaPromptVisible → commandPaletteVisible
+```
+
+### Backspace handling
+In the `tcell.KeyBackspace` case of `handleInput`, if the focused element is an `*tview.InputField` with empty text, dismiss the active prompt. Handles: quotaPrompt, updateQuotaPrompt, createVolumePrompt, createBucketPrompt, putFilePrompt, commandPalette, autoRefreshPrompt.
+In quota update wizard steps, per-step `SetInputCapture` handles Backspace for step-back navigation.
+
+### Async goroutine pattern
+```go
+go func(...) {
+    defer func() {
+        if r := recover(); r != nil {
+            errMsg := fmt.Sprintf("unexpected error: %v", r)
+            s.setStatus(fmt.Sprintf("[red]...: %s", errMsg))
+            s.queueUpdate(func() {
+                s.detailsView.SetText(fmt.Sprintf("[red]...: %s[-]", errMsg))
+            })
+        }
+    }()
+    result, err := someAPI(...)
+    if err != nil {
+        s.setStatus(...)
+        s.queueUpdate(func() { ... })
+        return
+    }
+    text := someFormatter(...)
+    s.queueUpdate(func() {
+        s.detailsView.SetText(text)
+    })
+}(...)
+```
+
+## types Package (oscar/v4)
+
+Key types used:
+- `types.Service` — service definition (Name, Image, CPU, Memory, Replicas, LogLevel)
+- `types.QuotaResponse` — `UserID`, `ClusterQueue`, `Resources map[string]QuotaValues` (Max/Used int64), `Volumes *VolumeQuotaResponse`
+- `types.VolumeQuotaResponse` — `Disk`, `Volumes` (both have Max/Used string), `MaxDiskperVolume`, `MinDiskperVolume`
+- `types.QuotaUpdateRequest` — `CPU`, `Memory` (strings), `Volumes *VolumeQuotaUpdate`
+- `types.VolumeQuotaUpdate` — `Disk`, `Volumes`, `MaxDiskperVolume`, `MinDiskperVolume` (strings, omitempty)
+- `types.ServiceDeploymentSummary` — `State` (DeploymentState enum), `Reason`, `LastTransitionTime *metav1.Time`, `ActiveInstances`, `AffectedInstances`, `ResourceKind`
+- `types.DeploymentLogStream` — `ServiceName`, `Available bool`, `Message`, `Entries []DeploymentLogEntry` (Timestamp, Message)
+- `types.MetricsSummaryResponse` — `Start/End time.Time`, `Totals` (ServicesCountActive/Total, CPUHoursTotal, GPUHoursTotal, RequestsCount*, UsersCount, CountriesCount), `Sources []MetricsSummarySource`
+- `types.ManagedVolume` — Name, Size, Status, Namespace, PVCName, OwnerUser, CreationMode, LifecyclePolicy, CreatedByService, Attachments
+- `types.Info` — Version, GitCommit, Architecture, KubeVersion, ServerlessBackendInfo
+- `types.JobsResponse` — list of jobs with pagination
+- `types.Replica` — federation replica definition
+
+---
+
+# Non-TUI Project Structure
+
+## Entry Point
+`main.go` → `cmd.Execute()` (from `cmd/root.go`)
+
+## CLI Framework
+Uses **`github.com/spf13/cobra`**. All commands in `cmd/` package.
+
+### Complete Command Tree
+```
+oscar-cli
+├── version
+├── cluster                         (cluster.go)
+│   ├── add IDENTIFIER ENDPOINT     (cluster_add.go)
+│   ├── delete IDENTIFIER           (cluster_remove.go)
+│   ├── info                        (cluster_info.go)
+│   ├── status                      (cluster_status.go)
+│   ├── list                        (cluster_list.go)
+│   └── default                     (cluster_default.go)
+├── service                         (service.go)
+│   ├── get SERVICE_NAME            (service_get.go)
+│   ├── list                        (service_list.go)
+│   ├── delete SERVICE_NAME...      (service_delete.go)
+│   ├── run SERVICE_NAME            (service_run.go)
+│   ├── job SERVICE_NAME            (service_job.go)
+│   ├── logs                        (service_logs.go)
+│   │   ├── list SERVICE_NAME       (service_logs_list.go)
+│   │   ├── get SERVICE_NAME [JOB]  (service_logs_get.go)
+│   │   └── delete SERVICE_NAME...  (service_logs_remove.go)
+│   ├── get-file SERVICE_NAME ...   (service_getfile.go)
+│   ├── put-file SERVICE_NAME ...   (service_putfile.go)
+│   ├── delete-file SERVICE_NAME... (service_deletefile.go)
+│   ├── list-files SERVICE_NAME...  (service_listfiles.go)
+│   ├── system-logs                 (system_logs.go)
+│   └── deployment                  (service_deployment.go)
+│       ├── status SERVICE_NAME     (service_deployment_status.go)
+│       └── logs SERVICE_NAME       (service_deployment_logs.go)
+├── bucket                          (bucket.go)
+│   ├── list                        (bucket_list.go)
+│   ├── get BUCKET_NAME             (bucket_get.go)
+│   ├── create BUCKET_NAME          (bucket_create.go)
+│   ├── update BUCKET_NAME          (bucket_update.go)
+│   ├── delete BUCKET_NAME          (bucket_delete.go)
+│   ├── put-file BUCKET ...         (bucket_put_file.go)
+│   ├── delete-file BUCKET ...      (bucket_delete_file.go)
+│   └── presign BUCKET FILE         (bucket_presign.go)
+├── hub                             (hub.go)
+│   ├── list                        (hub_list.go)
+│   ├── deploy SERVICE-SLUG         (hub_deploy.go)
+│   └── validate SERVICE-SLUG       (hub_validate.go)
+├── volume                          (volume.go)
+│   ├── list                        (volume_list.go)
+│   ├── create VOLUME_NAME          (volume_create.go)
+│   ├── get VOLUME_NAME             (volume_get.go)
+│   └── delete VOLUME_NAME          (volume_delete.go)
+├── quota                           (quota.go)
+│   ├── get [USER_ID]               (quota_get.go)
+│   └── update USER_ID              (quota_update.go)
+├── metrics                         (metrics.go)
+│   ├── summary                     (metrics_summary.go)
+│   ├── breakdown                   (metrics_breakdown.go)
+│   └── service SERVICE_NAME        (metrics_service.go)
+├── federation                      (federation.go)
+│   ├── get SERVICE_NAME            (federation_get.go)
+│   ├── create SERVICE_NAME         (federation_create.go)
+│   ├── update SERVICE_NAME         (federation_update.go)
+│   └── delete SERVICE_NAME         (federation_delete.go)
+├── apply FDL_FILE                  (apply.go)
+├── delete FDL_FILE                 (delete.go)
+├── interactive                     (interactive.go)
+└── health                          (health.go)
+```
+
+### root.go key vars
+- `var Version string` — set via ldflags at build
+- `var GitCommit string` — set via ldflags at build
+- `func Execute()` — called from main.go
+
+## Package Map (Non-TUI)
+
+| Package | Path | Responsibility |
+|---------|------|----------------|
+| `cmd` | `cmd/` | All cobra command definitions (53 prod files) |
+| `config` | `pkg/config/` | Config file read/write (YAML/JSON) at `~/.oscar-cli/config.yaml` |
+| `cluster` | `pkg/cluster/` | Cluster API client: HTTP transport, auth, info/status/health/quotas/metrics |
+| `service` | `pkg/service/` | Service CRUD, run/job, logs, deployment, federation, FDL parsing |
+| `storage` | `pkg/storage/` | Bucket CRUD, file upload/download/list/delete via MinIO/S3/Onedata |
+| `volume` | `pkg/volume/` | Managed volume CRUD |
+| `hub` | `pkg/hub/` | OSCAR Hub integration: list curated services, deploy FDL, validate |
+| `tui` | `pkg/tui/` | Terminal UI (covered above) |
+
+## pkg/config — Configuration Management
+
+**File**: `pkg/config/config.go`
+
+- `Config.Oscar map[string]*cluster.Cluster` — cluster configurations keyed by name
+- `Config.Default string` — default cluster name
+- `GetDefaultConfigPath() (string, error)` → `~/.oscar-cli/config.yaml`
+- `ReadConfig(configPath) (*Config, error)` — reads YAML or JSON
+- `(c *Config) AddCluster(configPath, id, endpoint, authUser, authPass, oidcName, oidcToken, sslVerify) error`
+- `(c *Config) RemoveCluster(configPath, id) error`
+- `(c *Config) CheckCluster(id) error`
+- `(c *Config) ClusterIDs() []string` — returns ordered cluster IDs
+- `(c *Config) SetDefault(configPath, id) error`
+- `(c *Config) GetCluster(defaultCluster, destClusterID, clusterName) (string, error)` — resolves target cluster from flags/FDL
+- `GetUserConfig(c *cluster.Cluster) (interface{}, error)` — GET `/system/config`
+
+## pkg/cluster — Cluster API Client
+
+**Files**: `cluster.go`, `status_types.go`, `health.go`, `quotas.go`, `metrics.go`
+
+### Cluster struct
+```go
+type Cluster struct {
+    Endpoint         string
+    AuthUser         string
+    AuthPassword     string
+    OIDCAccountName  string
+    OIDCRefreshToken string
+    SSLVerify        bool
+    Memory           string
+    LogLevel         string
+}
+```
+
+### Key methods
+- `(c *Cluster) GetClientSafe(args ...int) (*http.Client, error)` — creates authed HTTP client (Basic Auth, OIDC agent, or OIDC refresh token)
+- `(c *Cluster) GetClient(args ...int) *http.Client` — panics on error
+- `(c *Cluster) GetClusterInfo() (types.Info, error)` — GET `/system/info`
+- `(c *Cluster) GetClusterConfig() (types.Config, error)` — GET `/system/config`
+- `(c *Cluster) GetClusterStatus() (StatusInfo, error)` — GET `/system/status`
+- `(c *Cluster) HealthCheck() (*HealthCheckResponse, error)` — GET `/health`
+- `(c *Cluster) SetToken(client, token)` — injects bearer token round tripper
+
+### Standalone functions
+- `GetQuota(c, userID) (*types.QuotaResponse, error)` — GET `/system/quotas/user/{userID}`
+- `UpdateQuota(c, userID, cpu, memory, volUpdate) (*types.QuotaResponse, error)` — PUT `/system/quotas/user/{userID}`
+- `GetMetricsSummary(c, start, end) (*types.MetricsSummaryResponse, error)`
+- `GetMetricsBreakdown(c, groupBy, start, end) (*types.MetricsBreakdownResponse, error)`
+- `GetServiceMetrics(c, serviceName, start, end) (*types.ServiceMetricsResponse, error)`
+- `CheckStatusCode(res *http.Response) error`
+
+### Auth transport types
+- `basicAuthRoundTripper` — `Authorization: Basic`
+- `tokenRoundTripper` — `Authorization: Bearer`
+- `RefreshToken`, `ResponseRefreshToken` — OIDC refresh token flow
+
+## pkg/service — Service CRUD and Operations
+
+**Files**: `service.go`, `logs.go`, `deployment.go`, `federation.go`
+
+### FDL struct
+```go
+type FDL struct {
+    Functions struct {
+        Oscar []map[string]*types.Service
+    }
+    StorageProviders *types.StorageProviders
+    Clusters         map[string]types.Cluster
+}
+```
+
+### Key functions
+- `ReadFDL(path) (*FDL, error)` — parses FDL file, embeds scripts
+- `GetService(c, name) (*types.Service, error)` — GET `/system/services/{name}`
+- `ListServices(c) ([]*types.Service, error)` — GET `/system/services`
+- `ListServicesWithContext(ctx, c) ([]*types.Service, error)`
+- `RemoveService(c, name) error` — DELETE `/system/services/{name}`
+- `ApplyService(svc, c, method) error` — POST or PUT `/system/services`
+- `RunService(c, name, token, endpoint, input) (io.ReadCloser, error)` — synchronous POST `/run/{name}`
+- `JobService(c, name, token, endpoint, input) (io.ReadCloser, error)` — async POST `/job/{name}`
+- `ListLogs(c, name, page) (types.JobsResponse, error)` — GET `/system/logs/{name}`
+- `GetLogs(c, svcName, jobName, timestamps) (string, error)`
+- `GetSystemLogs(c, timestamps, previous) (string, error)`
+- `FindLatestJobName(c, svcName) (string, error)` — traverses pages to find newest
+- `RemoveLog(c, svcName, jobName) error`
+- `RemoveLogs(c, svcName, all) error`
+- `GetDeploymentStatus(c, name) (*types.ServiceDeploymentSummary, error)` — GET `/system/services/{name}/deployment`
+- `GetDeploymentLogs(c, name) (*types.DeploymentLogStream, error)` — GET `/system/services/{name}/deployment/logs`
+- `GetFederation(c, serviceName) ([]types.Replica, error)`
+- `CreateFederation(c, serviceName, replicas) error`
+- `UpdateFederation(c, serviceName, replicas) error`
+- `DeleteFederation(c, serviceName) error`
+
+## pkg/storage — Storage Provider Operations
+
+**Files**: `storage.go` (1226 lines), `progress.go`
+
+### Key structs
+```go
+type BucketInfo struct { Name, Provider, Visibility string; AllowedUsers []string; Owner string }
+type BucketObject struct { Name string; Size int64; LastModified time.Time; Owner string }
+type BucketListOptions struct { PageToken string; Limit int; AutoPaginate bool }
+type BucketListResult struct { Objects []*BucketObject; NextPage string; IsTruncated bool; ReturnedItems int }
+type PresignRequest struct { ObjectKey, Operation string; ExpiresIn int64; ContentType string; ExtraHeaders map[string]string }
+type TransferOption struct { ShowProgress bool }
+```
+
+### Key functions
+- `ListBuckets(c) ([]*BucketInfo, error)` — GET `/system/buckets`
+- `ListBucketsWithContext(ctx, c) ([]*BucketInfo, error)`
+- `CreateBucket(c, name, visibility, allowedUsers) error` — POST
+- `UpdateBucket(c, name, visibility, allowedUsers) error` — PUT
+- `DeleteBucket(c, name) error` — DELETE
+- `ListBucketObjectsWithOptions(c, bucketName, opts) (*BucketListResult, error)` — paginated
+- `ListBucketObjectsWithOptionsContext(ctx, c, bucketName, opts) (*BucketListResult, error)`
+- `PresignBucket(c, bucketName, req) (string, error)` — presigned URL
+- `GetFileWithService(c, svc, provider, remotePath, localPath, opt) error`
+- `PutFileWithService(c, svc, provider, localPath, remotePath, opt) error`
+- `DeleteFileWithService(c, svcName, provider, remotePath) error`
+- `ListFiles(c, svcName, provider, remotePath) ([]string, error)`
+- `DefaultRemotePath(svc, provider, localPath) (string, error)`
+- `DefaultOutputProvider(svc) (string, error)`
+- `DefaultOutputPath(svc, provider) (string, error)`
+- `ResolveLatestRemotePath(c, svc, provider, basePath) (string, error)`
+
+## pkg/volume — Managed Volume Operations
+
+**File**: `volume.go`
+
+- `ListVolumes(c) ([]types.ManagedVolume, error)` — GET `/system/volumes`
+- `CreateVolume(c, name, size) (*types.ManagedVolume, error)` — POST
+- `GetVolume(c, name) (*types.ManagedVolume, error)` — GET `/system/volumes/{name}`
+- `DeleteVolume(c, name) error` — DELETE
+
+## pkg/hub — OSCAR Hub Integration
+
+**Files**: `hub.go` (746 lines), `rocrate.go` (783 lines), `validate.go` (1602 lines)
+
+### Key types
+```go
+type Client struct { owner, repo, rootPath, ref, baseAPI string; httpClient *http.Client }
+type Service struct { Slug, Name, Description, Creator, URL, License, RepositoryURL, MetadataSource string }
+type ListResult struct { Services []Service; Warnings []Warning }
+type ROCrate struct { Context any; Graph []map[string]interface{}; index map[string]map[string]interface{} }
+type AcceptanceTest struct { ID, Name, Command, ExpectedSubstring string; Inputs []TestInput; Steps []AcceptanceStep }
+type AcceptanceStep struct { ID, Name, Command, ExpectedSubstring string; Inputs []TestInput }
+type AcceptanceResult struct { Test AcceptanceTest; Passed bool; Output, Details string; Err error; StepResults []AcceptanceStepResult }
+```
+
+### Key functions
+- `NewClient(opts ...Option) *Client`
+- `(c *Client) ListServices(ctx) (*ListResult, error)` — lists curated services from `github.com/grycap/oscar-hub`
+- `(c *Client) FetchFDL(ctx, slug) (*service.FDL, error)` — downloads FDL with embedded artifacts
+- `LoadLocalFDL(localRoot, slug) (*service.FDL, error)`
+- `ParseROCrate(raw) (*ROCrate, error)`
+- `(c *ROCrate) AcceptanceTests() ([]AcceptanceTest, error)`
+- `(c *Client) ValidateService(ctx, slug, clusterCfg, serviceNameOverride, localRoot) ([]AcceptanceResult, error)`
+- `(c *Client) AcceptanceCommands(ctx, slug, serviceNameOverride, localRoot) ([]AcceptanceCommandSet, error)`
+- `parseAcceptanceCommand(command) (parsedCommand, error)` — parses `oscar-cli service run/put-file/get-file/http`
+
+## Build and CI
+
+- **No Makefile** — builds via `go build`
+- **GitHub Actions** (`.github/workflows/main.yaml`):
+  - 5 build jobs: linux-amd64, linux-arm64, windows, darwin, darwin-arm64
+  - Release job attaches binaries to GitHub releases
+  - LDFLAGS inject version/commit:
+    ```sh
+    go build -ldflags "-s -w -X \"github.com/grycap/oscar-cli/cmd.Version=${VERSION}\" -X \"github.com/grycap/oscar-cli/cmd.GitCommit=${GITHUB_SHA::8}\""
+    ```
+- **Tests**: standard `go test` across all packages
+- **Test files**: `main_test.go`, `cmd/*_test.go` (22 files), `pkg/config/config_test.go`, `pkg/cluster/cluster_test.go`, `pkg/service/service_test.go`, `pkg/storage/storage_test.go`, `pkg/hub/*_test.go` (3 files), `pkg/tui/app_test.go`
+
+## Dependencies (Key Direct)
+
+| Module | Purpose |
+|--------|---------|
+| `spf13/cobra` | CLI framework |
+| `spf13/pflag` | Flag parsing |
+| `aws/aws-sdk-go` | S3 client for storage |
+| `gdamore/tcell/v2` | TUI terminal cell |
+| `rivo/tview` | TUI widgets |
+| `grycap/oscar/v4` | OSCAR API types |
+| `indigo-dc/liboidcagent-go` | OIDC agent |
+| `golang-jwt/jwt/v5` | JWT parsing |
+| `goccy/go-yaml` | YAML parsing |
+| `schollz/progressbar/v3` | Progress bars |
+| `fatih/color` | Colored output |
+| `briandowns/spinner` | Terminal spinners |
+| `adrg/xdg` | XDG base paths |
+| `grycap/cdmi-client-go` | Onedata CDMI client |
+| `k8s.io/api`, `apimachinery`, `client-go` | K8s types |
+| `sigs.k8s.io/kueue` | Kueue quota types |

--- a/cmd/federation.go
+++ b/cmd/federation.go
@@ -1,0 +1,44 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func federationFunc(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}
+
+func makeFederationCmd() *cobra.Command {
+	federationCmd := &cobra.Command{
+		Use:   "federation",
+		Short: "Manage service federation replicas",
+		Args:  cobra.NoArgs,
+		Run:   federationFunc,
+	}
+
+	federationCmd.PersistentFlags().StringP("cluster", "c", "", "set the cluster")
+	federationCmd.PersistentFlags().StringVar(&configPath, "config", defaultConfigPath, "set the location of the config file (YAML or JSON)")
+
+	federationCmd.AddCommand(makeFederationGetCmd())
+	federationCmd.AddCommand(makeFederationCreateCmd())
+	federationCmd.AddCommand(makeFederationUpdateCmd())
+	federationCmd.AddCommand(makeFederationDeleteCmd())
+
+	return federationCmd
+}

--- a/cmd/federation_create.go
+++ b/cmd/federation_create.go
@@ -1,0 +1,78 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/grycap/oscar-cli/pkg/config"
+	"github.com/grycap/oscar-cli/pkg/service"
+	"github.com/grycap/oscar/v4/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func federationCreateFunc(cmd *cobra.Command, args []string) error {
+	conf, err := config.ReadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	clusterName, err := getCluster(cmd, conf)
+	if err != nil {
+		return err
+	}
+
+	replicaType, _ := cmd.Flags().GetString("type")
+	clusterID, _ := cmd.Flags().GetString("cluster-id")
+	serviceName, _ := cmd.Flags().GetString("service-name")
+	url, _ := cmd.Flags().GetString("url")
+	priority, _ := cmd.Flags().GetUint("priority")
+
+	replica := types.Replica{
+		Type:        replicaType,
+		ClusterID:   clusterID,
+		ServiceName: serviceName,
+		URL:         url,
+		SSLVerify:   true,
+		Priority:    priority,
+	}
+
+	if err := service.CreateFederation(conf.Oscar[clusterName], args[0], []types.Replica{replica}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Federation replica created for service %q\n", args[0])
+
+	return nil
+}
+
+func makeFederationCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create SERVICE_NAME",
+		Short: "Create a federation replica for a service",
+		Args:  cobra.ExactArgs(1),
+		RunE:  federationCreateFunc,
+	}
+
+	cmd.Flags().String("type", "oscar", "replica type (oscar or endpoint)")
+	cmd.Flags().String("cluster-id", "", "cluster ID (for oscar type)")
+	cmd.Flags().String("service-name", "", "service name in the replica cluster (for oscar type)")
+	cmd.Flags().String("url", "", "endpoint URL (for endpoint type)")
+	cmd.Flags().Uint("priority", 0, "delegation priority (0 = highest)")
+
+	return cmd
+}

--- a/cmd/federation_delete.go
+++ b/cmd/federation_delete.go
@@ -1,0 +1,57 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/grycap/oscar-cli/pkg/config"
+	"github.com/grycap/oscar-cli/pkg/service"
+	"github.com/spf13/cobra"
+)
+
+func federationDeleteFunc(cmd *cobra.Command, args []string) error {
+	conf, err := config.ReadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	clusterName, err := getCluster(cmd, conf)
+	if err != nil {
+		return err
+	}
+
+	if err := service.DeleteFederation(conf.Oscar[clusterName], args[0]); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Federation replicas deleted for service %q\n", args[0])
+
+	return nil
+}
+
+func makeFederationDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete SERVICE_NAME",
+		Short:   "Delete federation replicas of a service",
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"rm"},
+		RunE:    federationDeleteFunc,
+	}
+
+	return cmd
+}

--- a/cmd/federation_get.go
+++ b/cmd/federation_get.go
@@ -1,0 +1,89 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/grycap/oscar-cli/pkg/config"
+	"github.com/grycap/oscar-cli/pkg/service"
+	"github.com/spf13/cobra"
+)
+
+func federationGetFunc(cmd *cobra.Command, args []string) error {
+	conf, err := config.ReadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	clusterName, err := getCluster(cmd, conf)
+	if err != nil {
+		return err
+	}
+
+	replicas, err := service.GetFederation(conf.Oscar[clusterName], args[0])
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	switch output {
+	case "json":
+		encoder := json.NewEncoder(cmd.OutOrStdout())
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(replicas)
+	case "table":
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 8, 2, ' ', 0)
+		fmt.Fprintln(w, "TYPE\tCLUSTER ID\tSERVICE NAME\tURL\tPRIORITY")
+		for _, r := range replicas {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", r.Type, r.ClusterID, r.ServiceName, r.URL, r.Priority)
+		}
+		w.Flush()
+		if len(replicas) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No federation replicas found")
+		}
+	default:
+		for _, r := range replicas {
+			fmt.Fprintf(cmd.OutOrStdout(), "Type: %s\n", r.Type)
+			fmt.Fprintf(cmd.OutOrStdout(), "Cluster ID: %s\n", r.ClusterID)
+			fmt.Fprintf(cmd.OutOrStdout(), "Service Name: %s\n", r.ServiceName)
+			fmt.Fprintf(cmd.OutOrStdout(), "URL: %s\n", r.URL)
+			fmt.Fprintf(cmd.OutOrStdout(), "Priority: %d\n\n", r.Priority)
+		}
+		if len(replicas) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No federation replicas found")
+		}
+	}
+
+	return nil
+}
+
+func makeFederationGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get SERVICE_NAME",
+		Short:   "Get federated replicas of a service",
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"g"},
+		RunE:    federationGetFunc,
+	}
+
+	cmd.Flags().StringP("output", "o", "text", "output format (text, json, table)")
+
+	return cmd
+}

--- a/cmd/federation_update.go
+++ b/cmd/federation_update.go
@@ -1,0 +1,78 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/grycap/oscar-cli/pkg/config"
+	"github.com/grycap/oscar-cli/pkg/service"
+	"github.com/grycap/oscar/v4/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func federationUpdateFunc(cmd *cobra.Command, args []string) error {
+	conf, err := config.ReadConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	clusterName, err := getCluster(cmd, conf)
+	if err != nil {
+		return err
+	}
+
+	replicaType, _ := cmd.Flags().GetString("type")
+	clusterID, _ := cmd.Flags().GetString("cluster-id")
+	serviceName, _ := cmd.Flags().GetString("service-name")
+	url, _ := cmd.Flags().GetString("url")
+	priority, _ := cmd.Flags().GetUint("priority")
+
+	replica := types.Replica{
+		Type:        replicaType,
+		ClusterID:   clusterID,
+		ServiceName: serviceName,
+		URL:         url,
+		SSLVerify:   true,
+		Priority:    priority,
+	}
+
+	if err := service.UpdateFederation(conf.Oscar[clusterName], args[0], []types.Replica{replica}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Federation replica updated for service %q\n", args[0])
+
+	return nil
+}
+
+func makeFederationUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update SERVICE_NAME",
+		Short: "Update a federation replica for a service",
+		Args:  cobra.ExactArgs(1),
+		RunE:  federationUpdateFunc,
+	}
+
+	cmd.Flags().String("type", "oscar", "replica type (oscar or endpoint)")
+	cmd.Flags().String("cluster-id", "", "cluster ID (for oscar type)")
+	cmd.Flags().String("service-name", "", "service name in the replica cluster (for oscar type)")
+	cmd.Flags().String("url", "", "endpoint URL (for endpoint type)")
+	cmd.Flags().Uint("priority", 0, "delegation priority (0 = highest)")
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,7 @@ func newRootCommand() *cobra.Command {
 	cmd.AddCommand(makeInteractiveCmd())
 	cmd.AddCommand(makeDeleteCmd())
 	cmd.AddCommand(makeHealthCmd())
+	cmd.AddCommand(makeFederationCmd())
 
 	return cmd
 }

--- a/pkg/service/federation.go
+++ b/pkg/service/federation.go
@@ -1,0 +1,119 @@
+/*
+Copyright (C) GRyCAP - I3M - UPV
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/grycap/oscar-cli/pkg/cluster"
+	"github.com/grycap/oscar/v4/pkg/types"
+)
+
+const federationPath = "/system/federation"
+
+// GetFederation returns the federated replicas of a service.
+func GetFederation(c *cluster.Cluster, serviceName string) ([]types.Replica, error) {
+	getURL, err := url.Parse(c.Endpoint)
+	if err != nil {
+		return nil, cluster.ErrParsingEndpoint
+	}
+	getURL.Path = path.Join(getURL.Path, federationPath, serviceName)
+
+	req, err := http.NewRequest(http.MethodGet, getURL.String(), nil)
+	if err != nil {
+		return nil, cluster.ErrMakingRequest
+	}
+
+	client, err := c.GetClientSafe()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, cluster.ErrSendingRequest
+	}
+	defer res.Body.Close()
+
+	if err := cluster.CheckStatusCode(res); err != nil {
+		return nil, err
+	}
+
+	var replicas []types.Replica
+	if err := json.NewDecoder(res.Body).Decode(&replicas); err != nil {
+		return nil, err
+	}
+
+	return replicas, nil
+}
+
+// CreateFederation creates federated replicas for a service.
+func CreateFederation(c *cluster.Cluster, serviceName string, replicas []types.Replica) error {
+	return federationRequest(c, http.MethodPost, serviceName, replicas)
+}
+
+// UpdateFederation updates federated replicas for a service.
+func UpdateFederation(c *cluster.Cluster, serviceName string, replicas []types.Replica) error {
+	return federationRequest(c, http.MethodPut, serviceName, replicas)
+}
+
+// DeleteFederation deletes federated replicas for a service.
+func DeleteFederation(c *cluster.Cluster, serviceName string) error {
+	return federationRequest(c, http.MethodDelete, serviceName, nil)
+}
+
+func federationRequest(c *cluster.Cluster, method, serviceName string, replicas []types.Replica) error {
+	reqURL, err := url.Parse(c.Endpoint)
+	if err != nil {
+		return cluster.ErrParsingEndpoint
+	}
+	reqURL.Path = path.Join(reqURL.Path, federationPath, serviceName)
+
+	var body *bytes.Buffer
+	if replicas != nil {
+		bodyBytes, err := json.Marshal(replicas)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewBuffer(bodyBytes)
+	}
+
+	req, err := http.NewRequest(method, reqURL.String(), body)
+	if err != nil {
+		return cluster.ErrMakingRequest
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	client, err := c.GetClientSafe()
+	if err != nil {
+		return err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return cluster.ErrSendingRequest
+	}
+	defer res.Body.Close()
+
+	return cluster.CheckStatusCode(res)
+}

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -514,6 +514,20 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 		}
 		return event
 	}
+	if s.createBucketPromptVisible {
+		if event.Key() == tcell.KeyEsc {
+			s.hideCreateBucketPrompt()
+			return nil
+		}
+		return event
+	}
+	if s.putFilePromptVisible {
+		if event.Key() == tcell.KeyEsc {
+			s.hidePutFilePrompt()
+			return nil
+		}
+		return event
+	}
 
 	switch event.Key() {
 	case tcell.KeyTab:
@@ -589,6 +603,10 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 			s.promptCreateVolume()
 			return nil
 		}
+		if s.modeIsBuckets() {
+			s.promptCreateBucket()
+			return nil
+		}
 	case 'b', 'B':
 		s.switchToBuckets(ctx)
 		return nil
@@ -598,6 +616,11 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 	case 's', 'S':
 		s.switchToServices(ctx)
 		return nil
+	case 'u', 'U':
+		if s.modeIsBuckets() && s.app.GetFocus() == s.bucketObjectsTable {
+			s.promptPutFile()
+			return nil
+		}
 	case 'o', 'O':
 		if s.modeIsBuckets() {
 			s.reloadBucketObjects(ctx)
@@ -622,6 +645,10 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 	case 'd', 'D':
 		if s.app.GetFocus() == s.serviceTable {
 			s.requestDeletion()
+			return nil
+		}
+		if s.app.GetFocus() == s.bucketObjectsTable {
+			s.requestBucketObjectDeletion()
 			return nil
 		}
 	case 'v', 'V':

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grycap/oscar-cli/pkg/cluster"
 	"github.com/grycap/oscar-cli/pkg/config"
+	"github.com/grycap/oscar-cli/pkg/service"
 	"github.com/grycap/oscar/v4/pkg/types"
 )
 
@@ -697,6 +698,12 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 	case 'k', 'K':
 		s.promptUpdateQuota()
 		return nil
+	case 't', 'T':
+		s.showServiceDeploymentStatus(ctx)
+		return nil
+	case 'h', 'H':
+		s.showServiceDeploymentLogs(ctx)
+		return nil
 	case '/':
 		s.initiateSearch(ctx)
 		return nil
@@ -1261,6 +1268,164 @@ func (s *uiState) performUpdateQuota(cfg *cluster.Cluster, uid, cpu, mem, volDis
 			s.detailsView.SetText(text)
 		})
 	}(clusterName, uid, cpu, mem, volUpdate, cfg)
+}
+
+func (s *uiState) showServiceDeploymentStatus(ctx context.Context) {
+	if s.searchVisible {
+		s.hideSearch()
+	}
+
+	s.mutex.Lock()
+	if s.confirmVisible || s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	if s.mode != modeServices {
+		s.mutex.Unlock()
+		s.setStatus("[red]Deployment status is only available in services view")
+		return
+	}
+
+	row, _ := s.serviceTable.GetSelection()
+	if row <= 0 || row-1 >= len(s.currentServices) {
+		s.mutex.Unlock()
+		s.setStatus("[red]Select a service to view deployment status")
+		return
+	}
+	svcPtr := s.currentServices[row-1]
+	clusterName := s.currentCluster
+	s.mutex.Unlock()
+
+	if svcPtr == nil {
+		s.setStatus("[red]Select a service to view deployment status")
+		return
+	}
+	serviceName := strings.TrimSpace(svcPtr.Name)
+	if serviceName == "" {
+		s.setStatus("[red]Select a service to view deployment status")
+		return
+	}
+
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" {
+		s.setStatus("[red]Select a cluster to view deployment status")
+		return
+	}
+
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading deployment status for %q…", serviceName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("[yellow]Loading deployment status for %q…[-]", serviceName))
+	})
+
+	go func(svcName, clName string, cfg *cluster.Cluster) {
+		defer func() {
+			if r := recover(); r != nil {
+				errMsg := fmt.Sprintf("unexpected error: %v", r)
+				s.setStatus(fmt.Sprintf("[red]Failed to load deployment status for %q: %s", svcName, errMsg))
+				s.queueUpdate(func() {
+					s.detailsView.SetText(fmt.Sprintf("[red]Failed to load deployment status for %q: %s[-]", svcName, errMsg))
+				})
+			}
+		}()
+		ds, err := service.GetDeploymentStatus(cfg, svcName)
+		if err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to load deployment status for %q: %v", svcName, err))
+			s.queueUpdate(func() {
+				s.detailsView.SetText(fmt.Sprintf("[red]Failed to load deployment status for %q:\n%v[-]", svcName, err))
+			})
+			return
+		}
+		s.setStatus(fmt.Sprintf("[green]Deployment status loaded for %q", svcName))
+		text := formatDeploymentStatus(svcName, ds)
+		s.queueUpdate(func() {
+			s.detailsView.SetText(text)
+		})
+	}(serviceName, clusterName, clusterCfg)
+}
+
+func (s *uiState) showServiceDeploymentLogs(ctx context.Context) {
+	if s.searchVisible {
+		s.hideSearch()
+	}
+
+	s.mutex.Lock()
+	if s.confirmVisible || s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	if s.mode != modeServices {
+		s.mutex.Unlock()
+		s.setStatus("[red]Deployment logs are only available in services view")
+		return
+	}
+
+	row, _ := s.serviceTable.GetSelection()
+	if row <= 0 || row-1 >= len(s.currentServices) {
+		s.mutex.Unlock()
+		s.setStatus("[red]Select a service to view deployment logs")
+		return
+	}
+	svcPtr := s.currentServices[row-1]
+	clusterName := s.currentCluster
+	s.mutex.Unlock()
+
+	if svcPtr == nil {
+		s.setStatus("[red]Select a service to view deployment logs")
+		return
+	}
+	serviceName := strings.TrimSpace(svcPtr.Name)
+	if serviceName == "" {
+		s.setStatus("[red]Select a service to view deployment logs")
+		return
+	}
+
+	clusterName = strings.TrimSpace(clusterName)
+	if clusterName == "" {
+		s.setStatus("[red]Select a cluster to view deployment logs")
+		return
+	}
+
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading deployment logs for %q…", serviceName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("[yellow]Loading deployment logs for %q…[-]", serviceName))
+	})
+
+	go func(svcName, clName string, cfg *cluster.Cluster) {
+		defer func() {
+			if r := recover(); r != nil {
+				errMsg := fmt.Sprintf("unexpected error: %v", r)
+				s.setStatus(fmt.Sprintf("[red]Failed to load deployment logs for %q: %s", svcName, errMsg))
+				s.queueUpdate(func() {
+					s.detailsView.SetText(fmt.Sprintf("[red]Failed to load deployment logs for %q: %s[-]", svcName, errMsg))
+				})
+			}
+		}()
+		dl, err := service.GetDeploymentLogs(cfg, svcName)
+		if err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to load deployment logs for %q: %v", svcName, err))
+			s.queueUpdate(func() {
+				s.detailsView.SetText(fmt.Sprintf("[red]Failed to load deployment logs for %q:\n%v[-]", svcName, err))
+			})
+			return
+		}
+		s.setStatus(fmt.Sprintf("[green]Deployment logs loaded for %q", svcName))
+		text := formatDeploymentLogs(dl)
+		s.queueUpdate(func() {
+			s.detailsView.SetText(text)
+		})
+	}(serviceName, clusterName, clusterCfg)
 }
 
 func formatClusterStatus(clusterName string, status cluster.StatusInfo) string {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -49,6 +49,8 @@ func Run(ctx context.Context, conf *config.Config) error {
 		logDetails:         make(map[string]string),
 	}
 
+	state.initCommands()
+
 	state.statusView.SetBorder(false)
 	state.detailsView.SetBorder(true)
 	state.detailsView.SetScrollable(true)
@@ -544,6 +546,13 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 		}
 		return event
 	}
+	if s.commandPaletteVisible {
+		if event.Key() == tcell.KeyEsc {
+			s.hideCommandPalette()
+			return nil
+		}
+		return event
+	}
 	switch event.Key() {
 	case tcell.KeyTab:
 		if s.app.GetFocus() == s.clusterList {
@@ -588,6 +597,24 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 			return nil
 		}
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if inp, ok := s.app.GetFocus().(*tview.InputField); ok && inp.GetText() == "" {
+			if s.quotaPromptVisible {
+				s.hideQuotaPrompt()
+			} else if s.updateQuotaPromptVisible {
+				s.hideUpdateQuotaPrompt()
+			} else if s.createVolumePromptVisible {
+				s.hideCreateVolumePrompt()
+			} else if s.createBucketPromptVisible {
+				s.hideCreateBucketPrompt()
+			} else if s.putFilePromptVisible {
+				s.hidePutFilePrompt()
+			} else if s.commandPaletteVisible {
+				s.hideCommandPalette()
+			} else if s.autoRefreshPromptVisible {
+				s.hideAutoRefreshPrompt()
+			}
+			return nil
+		}
 		if s.app.GetFocus() == s.detailsView {
 			s.app.SetFocus(s.serviceTable)
 			return nil
@@ -703,6 +730,9 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 		return nil
 	case 'h', 'H':
 		s.showServiceDeploymentLogs(ctx)
+		return nil
+	case ':':
+		s.showCommandPalette()
 		return nil
 	case '/':
 		s.initiateSearch(ctx)
@@ -1061,6 +1091,13 @@ func (s *uiState) promptUpdateQuotaUserID(cfg *cluster.Cluster) {
 	input := tview.NewInputField()
 	input.SetLabel("User ID: ")
 	input.SetFieldWidth(40)
+	input.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if (event.Key() == tcell.KeyBackspace || event.Key() == tcell.KeyBackspace2) && input.GetText() == "" {
+			s.hideUpdateQuotaPrompt()
+			return nil
+		}
+		return event
+	})
 	input.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEnter {
 			uid := strings.TrimSpace(input.GetText())
@@ -1095,6 +1132,14 @@ func (s *uiState) promptUpdateQuotaCPU(cfg *cluster.Cluster) {
 	input := tview.NewInputField()
 	input.SetLabel("CPU quota (e.g. 2, 500m, empty=unchanged): ")
 	input.SetFieldWidth(30)
+	input.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if (event.Key() == tcell.KeyBackspace || event.Key() == tcell.KeyBackspace2) && input.GetText() == "" {
+			s.hideUpdateQuotaPrompt()
+			s.promptUpdateQuotaUserID(cfg)
+			return nil
+		}
+		return event
+	})
 	input.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEnter {
 			cpu := strings.TrimSpace(input.GetText())
@@ -1130,6 +1175,14 @@ func (s *uiState) promptUpdateQuotaMemory(cfg *cluster.Cluster) {
 	input := tview.NewInputField()
 	input.SetLabel("Memory quota (e.g. 2Gi, 512Mi, empty=unchanged): ")
 	input.SetFieldWidth(30)
+	input.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if (event.Key() == tcell.KeyBackspace || event.Key() == tcell.KeyBackspace2) && input.GetText() == "" {
+			s.hideUpdateQuotaPrompt()
+			s.promptUpdateQuotaCPU(cfg)
+			return nil
+		}
+		return event
+	})
 	input.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEnter {
 			mem := strings.TrimSpace(input.GetText())
@@ -1157,6 +1210,14 @@ func (s *uiState) promptUpdateQuotaVolumeDisk(cfg *cluster.Cluster, uid, cpu, me
 	input := tview.NewInputField()
 	input.SetLabel("Volume disk (e.g. 5Gi, empty=unchanged): ")
 	input.SetFieldWidth(30)
+	input.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if (event.Key() == tcell.KeyBackspace || event.Key() == tcell.KeyBackspace2) && input.GetText() == "" {
+			s.hideUpdateQuotaPrompt()
+			s.promptUpdateQuotaMemory(cfg)
+			return nil
+		}
+		return event
+	})
 	input.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEnter {
 			volDisk := strings.TrimSpace(input.GetText())
@@ -1187,6 +1248,14 @@ func (s *uiState) promptUpdateQuotaVolumeCount(cfg *cluster.Cluster, uid, cpu, m
 	input := tview.NewInputField()
 	input.SetLabel("Volume count (e.g. 3, empty=unchanged): ")
 	input.SetFieldWidth(30)
+	input.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if (event.Key() == tcell.KeyBackspace || event.Key() == tcell.KeyBackspace2) && input.GetText() == "" {
+			s.hideUpdateQuotaPrompt()
+			s.promptUpdateQuotaVolumeDisk(cfg, uid, cpu, mem)
+			return nil
+		}
+		return event
+	})
 	input.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEnter {
 			volCount := strings.TrimSpace(input.GetText())

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -611,10 +611,22 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 		s.switchToBuckets(ctx)
 		return nil
 	case 'm', 'M':
-		s.switchToVolumes(ctx)
+		s.showMetricsSummary()
 		return nil
 	case 's', 'S':
 		s.switchToServices(ctx)
+		return nil
+	case 'v', 'V':
+		s.switchToVolumes(ctx)
+		return nil
+	case 'f', 'F':
+		s.queueUpdate(func() {
+			if s.app.GetFocus() != s.detailsView {
+				s.app.SetFocus(s.detailsView)
+			} else {
+				s.app.SetFocus(s.serviceTable)
+			}
+		})
 		return nil
 	case 'u', 'U':
 		if s.modeIsBuckets() && s.app.GetFocus() == s.bucketObjectsTable {
@@ -651,15 +663,6 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 			s.requestBucketObjectDeletion()
 			return nil
 		}
-	case 'v', 'V':
-		s.queueUpdate(func() {
-			if s.app.GetFocus() != s.detailsView {
-				s.app.SetFocus(s.detailsView)
-			} else {
-				s.app.SetFocus(s.serviceTable)
-			}
-		})
-		return nil
 	case 'l', 'L':
 		if s.app.GetFocus() == s.serviceTable {
 			s.switchToLogs(ctx)
@@ -671,7 +674,7 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 	case 'i', 'I':
 		s.showClusterInfo()
 		return nil
-	case 't', 'T':
+	case 'e', 'E':
 		s.showClusterStatus()
 		return nil
 	case '/':
@@ -729,11 +732,26 @@ func (s *uiState) showClusterInfo() {
 	}
 
 	s.setStatus(fmt.Sprintf("[yellow]Loading info for cluster %q…", displayName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("[yellow]Loading info for %q…[-]", displayName))
+	})
 
 	go func(name string, cfg *cluster.Cluster) {
+		defer func() {
+			if r := recover(); r != nil {
+				errMsg := fmt.Sprintf("unexpected error: %v", r)
+				s.setStatus(fmt.Sprintf("[red]Failed to load info for %q: %s", name, errMsg))
+				s.queueUpdate(func() {
+					s.detailsView.SetText(fmt.Sprintf("[red]Failed to load info for %q: %s[-]", name, errMsg))
+				})
+			}
+		}()
 		info, err := cfg.GetClusterInfo()
 		if err != nil {
 			s.setStatus(fmt.Sprintf("[red]Failed to load info for %q: %v", name, err))
+			s.queueUpdate(func() {
+				s.detailsView.SetText(fmt.Sprintf("[red]Failed to load info for %q:\n%v[-]", name, err))
+			})
 			return
 		}
 		s.setStatus(fmt.Sprintf("[green]Cluster info loaded for %q", name))
@@ -774,15 +792,90 @@ func (s *uiState) showClusterStatus() {
 	}
 
 	s.setStatus(fmt.Sprintf("[yellow]Loading status for cluster %q…", displayName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("[yellow]Loading status for %q…[-]", displayName))
+	})
 
 	go func(name string, cfg *cluster.Cluster) {
+		defer func() {
+			if r := recover(); r != nil {
+				errMsg := fmt.Sprintf("unexpected error: %v", r)
+				s.setStatus(fmt.Sprintf("[red]Failed to load status for %q: %s", name, errMsg))
+				s.queueUpdate(func() {
+					s.detailsView.SetText(fmt.Sprintf("[red]Failed to load status for %q: %s[-]", name, errMsg))
+				})
+			}
+		}()
 		status, err := cfg.GetClusterStatus()
 		if err != nil {
 			s.setStatus(fmt.Sprintf("[red]Failed to load status for %q: %v", name, err))
+			s.queueUpdate(func() {
+				s.detailsView.SetText(fmt.Sprintf("[red]Failed to load status for %q:\n%v[-]", name, err))
+			})
 			return
 		}
 		s.setStatus(fmt.Sprintf("[green]Cluster status loaded for %q", name))
 		text := formatClusterStatus(name, status)
+		s.queueUpdate(func() {
+			s.detailsView.SetText(text)
+		})
+	}(displayName, clusterCfg)
+}
+
+func (s *uiState) showMetricsSummary() {
+	s.mutex.Lock()
+	if s.confirmVisible || s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	clusterName := s.currentCluster
+	s.mutex.Unlock()
+
+	trimmedName := strings.TrimSpace(clusterName)
+	if trimmedName == "" {
+		s.setStatus("[red]Select a cluster to view metrics")
+		return
+	}
+
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil && trimmedName != clusterName {
+		clusterCfg = s.conf.Oscar[trimmedName]
+	}
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", trimmedName))
+		return
+	}
+
+	displayName := trimmedName
+	if displayName == "" {
+		displayName = clusterName
+	}
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading metrics for cluster %q…", displayName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("[yellow]Loading metrics for %q…[-]", displayName))
+	})
+
+	go func(name string, cfg *cluster.Cluster) {
+		defer func() {
+			if r := recover(); r != nil {
+				errMsg := fmt.Sprintf("unexpected error: %v", r)
+				s.setStatus(fmt.Sprintf("[red]Failed to load metrics for %q: %s", name, errMsg))
+				s.queueUpdate(func() {
+					s.detailsView.SetText(fmt.Sprintf("[red]Failed to load metrics for %q: %s[-]", name, errMsg))
+				})
+			}
+		}()
+		summary, err := cluster.GetMetricsSummary(cfg, "", "")
+		if err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to load metrics for %q: %v", name, err))
+			s.queueUpdate(func() {
+				s.detailsView.SetText(fmt.Sprintf("[red]Failed to load metrics for %q:\n%v[-]", name, err))
+			})
+			return
+		}
+		s.setStatus(fmt.Sprintf("[green]Metrics loaded for %q", name))
+		text := formatMetricsSummary(name, summary)
 		s.queueUpdate(func() {
 			s.detailsView.SetText(text)
 		})

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -528,7 +528,6 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 		}
 		return event
 	}
-
 	switch event.Key() {
 	case tcell.KeyTab:
 		if s.app.GetFocus() == s.clusterList {
@@ -676,6 +675,9 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 		return nil
 	case 'e', 'E':
 		s.showClusterStatus()
+		return nil
+	case 'g', 'G':
+		s.showQuota()
 		return nil
 	case '/':
 		s.initiateSearch(ctx)
@@ -880,6 +882,54 @@ func (s *uiState) showMetricsSummary() {
 			s.detailsView.SetText(text)
 		})
 	}(displayName, clusterCfg)
+}
+
+func (s *uiState) showQuota() {
+	s.mutex.Lock()
+	if s.searchVisible || s.autoRefreshPromptVisible ||
+		s.confirmVisible || s.legendVisible || s.pages == nil ||
+		s.currentCluster == "" {
+		s.mutex.Unlock()
+		return
+	}
+	clusterName := s.currentCluster
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.mutex.Unlock()
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+	s.mutex.Unlock()
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading quota for %q…", clusterName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("[yellow]Loading quota for %q…[-]", clusterName))
+	})
+
+	go func(name string, cfg *cluster.Cluster) {
+		defer func() {
+			if r := recover(); r != nil {
+				errMsg := fmt.Sprintf("unexpected error: %v", r)
+				s.setStatus(fmt.Sprintf("[red]Failed to load quota for %q: %s", name, errMsg))
+				s.queueUpdate(func() {
+					s.detailsView.SetText(fmt.Sprintf("[red]Failed to load quota for %q: %s[-]", name, errMsg))
+				})
+			}
+		}()
+		quota, err := cluster.GetQuota(cfg, "")
+		if err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to load quota for %q: %v", name, err))
+			s.queueUpdate(func() {
+				s.detailsView.SetText(fmt.Sprintf("[red]Failed to load quota for %q:\n%v[-]", name, err))
+			})
+			return
+		}
+		s.setStatus(fmt.Sprintf("[green]Quota loaded for %q", name))
+		text := formatQuota(name, quota)
+		s.queueUpdate(func() {
+			s.detailsView.SetText(text)
+		})
+	}(clusterName, clusterCfg)
 }
 
 func formatClusterStatus(clusterName string, status cluster.StatusInfo) string {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/grycap/oscar-cli/pkg/cluster"
 	"github.com/grycap/oscar-cli/pkg/config"
+	"github.com/grycap/oscar/v4/pkg/types"
 )
 
 // Run launches the interactive terminal user interface.
@@ -528,6 +529,20 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 		}
 		return event
 	}
+	if s.quotaPromptVisible {
+		if event.Key() == tcell.KeyEsc {
+			s.hideQuotaPrompt()
+			return nil
+		}
+		return event
+	}
+	if s.updateQuotaPromptVisible {
+		if event.Key() == tcell.KeyEsc {
+			s.hideUpdateQuotaPrompt()
+			return nil
+		}
+		return event
+	}
 	switch event.Key() {
 	case tcell.KeyTab:
 		if s.app.GetFocus() == s.clusterList {
@@ -677,7 +692,10 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 		s.showClusterStatus()
 		return nil
 	case 'g', 'G':
-		s.showQuota()
+		s.showQuotaPrompt()
+		return nil
+	case 'k', 'K':
+		s.promptUpdateQuota()
 		return nil
 	case '/':
 		s.initiateSearch(ctx)
@@ -884,29 +902,95 @@ func (s *uiState) showMetricsSummary() {
 	}(displayName, clusterCfg)
 }
 
-func (s *uiState) showQuota() {
+func (s *uiState) showQuotaPrompt() {
 	s.mutex.Lock()
-	if s.searchVisible || s.autoRefreshPromptVisible ||
+	if s.quotaPromptVisible || s.searchVisible || s.autoRefreshPromptVisible ||
 		s.confirmVisible || s.legendVisible || s.pages == nil ||
 		s.currentCluster == "" {
 		s.mutex.Unlock()
 		return
 	}
-	clusterName := s.currentCluster
-	clusterCfg := s.conf.Oscar[clusterName]
+	s.quotaPromptVisible = true
+	s.quotaFocus = s.app.GetFocus()
+	container := s.statusContainer
+	clusterCfg := s.conf.Oscar[s.currentCluster]
 	if clusterCfg == nil {
 		s.mutex.Unlock()
-		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", s.currentCluster))
+		s.hideQuotaPrompt()
 		return
 	}
+	usesBasicAuth := clusterCfg.AuthUser != "" && clusterCfg.AuthPassword != ""
 	s.mutex.Unlock()
 
-	s.setStatus(fmt.Sprintf("[yellow]Loading quota for %q…", clusterName))
-	s.queueUpdate(func() {
-		s.detailsView.SetText(fmt.Sprintf("[yellow]Loading quota for %q…[-]", clusterName))
+	if !usesBasicAuth {
+		s.hideQuotaPrompt()
+		s.performFetchQuota(s.currentCluster, "", clusterCfg)
+		return
+	}
+
+	input := tview.NewInputField()
+	input.SetLabel("User ID: ")
+	input.SetFieldWidth(40)
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			uid := strings.TrimSpace(input.GetText())
+			if uid == "" {
+				s.setStatus("[red]Please enter a valid user ID for basic auth clusters")
+				s.queueUpdate(func() {
+					s.detailsView.SetText("[red]User ID is required when using auth_user/auth_password authentication.\nEnter a non-empty user ID to look up quotas.[-]")
+				})
+				return
+			}
+			s.hideQuotaPrompt()
+			s.setStatus(fmt.Sprintf("[green]Loading quota for %q...", displayUserID(uid)))
+			s.performFetchQuota(s.currentCluster, uid, clusterCfg)
+		} else if key == tcell.KeyEscape {
+			s.hideQuotaPrompt()
+		}
 	})
 
-	go func(name string, cfg *cluster.Cluster) {
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Quota Lookup")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) hideQuotaPrompt() {
+	s.mutex.Lock()
+	if !s.quotaPromptVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.quotaPromptVisible = false
+	focus := s.quotaFocus
+	s.quotaFocus = nil
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Status")
+		container.AddItem(s.statusView, 0, 1, false)
+		s.statusView.SetText(s.decorateStatusText(statusHelpText))
+	})
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
+}
+
+func (s *uiState) performFetchQuota(name string, userID string, cfg *cluster.Cluster) {
+	displayName := name
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading quota for %q…", displayName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("[yellow]Loading quota for %q…[-]", displayName))
+	})
+
+	go func(name, uid string, clusterCfg *cluster.Cluster) {
 		defer func() {
 			if r := recover(); r != nil {
 				errMsg := fmt.Sprintf("unexpected error: %v", r)
@@ -916,7 +1000,7 @@ func (s *uiState) showQuota() {
 				})
 			}
 		}()
-		quota, err := cluster.GetQuota(cfg, "")
+		quota, err := cluster.GetQuota(clusterCfg, uid)
 		if err != nil {
 			s.setStatus(fmt.Sprintf("[red]Failed to load quota for %q: %v", name, err))
 			s.queueUpdate(func() {
@@ -929,7 +1013,254 @@ func (s *uiState) showQuota() {
 		s.queueUpdate(func() {
 			s.detailsView.SetText(text)
 		})
-	}(clusterName, clusterCfg)
+	}(displayName, userID, cfg)
+}
+
+func displayUserID(userID string) string {
+	if userID == "" {
+		return "all users"
+	}
+	return userID
+}
+
+func (s *uiState) promptUpdateQuota() {
+	s.mutex.Lock()
+	if s.updateQuotaPromptVisible || s.quotaPromptVisible || s.searchVisible ||
+		s.autoRefreshPromptVisible || s.confirmVisible || s.legendVisible ||
+		s.pages == nil || s.currentCluster == "" {
+		s.mutex.Unlock()
+		return
+	}
+	clusterCfg := s.conf.Oscar[s.currentCluster]
+	if clusterCfg == nil {
+		s.mutex.Unlock()
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", s.currentCluster))
+		return
+	}
+	if clusterCfg.AuthUser == "" || clusterCfg.AuthPassword == "" {
+		s.mutex.Unlock()
+		s.setStatus("[red]Quota update is only available for clusters with auth_user/auth_password")
+		return
+	}
+	s.updateQuotaPromptVisible = true
+	s.updateQuotaStep = 0
+	s.updateQuotaFocus = s.app.GetFocus()
+	s.mutex.Unlock()
+
+	s.promptUpdateQuotaUserID(clusterCfg)
+}
+
+func (s *uiState) promptUpdateQuotaUserID(cfg *cluster.Cluster) {
+	input := tview.NewInputField()
+	input.SetLabel("User ID: ")
+	input.SetFieldWidth(40)
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			uid := strings.TrimSpace(input.GetText())
+			if uid == "" {
+				s.setStatus("[red]User ID cannot be empty")
+				return
+			}
+			s.mutex.Lock()
+			s.updateQuotaUserID = uid
+			s.mutex.Unlock()
+			s.hideUpdateQuotaPrompt()
+			s.promptUpdateQuotaCPU(cfg)
+		} else if key == tcell.KeyEscape {
+			s.hideUpdateQuotaPrompt()
+		}
+	})
+	s.setStatus("[yellow]Enter user ID to update quota:[-]")
+	s.queueUpdate(func() {
+		s.statusContainer.Clear()
+		s.statusContainer.SetTitle("Update Quota (user ID)")
+		input.SetBorder(false)
+		s.statusContainer.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) promptUpdateQuotaCPU(cfg *cluster.Cluster) {
+	s.mutex.Lock()
+	s.updateQuotaPromptVisible = true
+	s.mutex.Unlock()
+
+	input := tview.NewInputField()
+	input.SetLabel("CPU quota (e.g. 2, 500m, empty=unchanged): ")
+	input.SetFieldWidth(30)
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			cpu := strings.TrimSpace(input.GetText())
+			s.mutex.Lock()
+			s.updateQuotaCPU = cpu
+			s.mutex.Unlock()
+			s.hideUpdateQuotaPrompt()
+			s.promptUpdateQuotaMemory(cfg)
+		} else if key == tcell.KeyEscape {
+			s.hideUpdateQuotaPrompt()
+		}
+	})
+	s.setStatus("[yellow]Enter CPU quota (or leave empty to keep current):[-]")
+	s.queueUpdate(func() {
+		s.statusContainer.Clear()
+		s.statusContainer.SetTitle("Update Quota (CPU)")
+		input.SetBorder(false)
+		s.statusContainer.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) promptUpdateQuotaMemory(cfg *cluster.Cluster) {
+	s.mutex.Lock()
+	s.updateQuotaPromptVisible = true
+	s.mutex.Unlock()
+
+	s.mutex.Lock()
+	uid := s.updateQuotaUserID
+	cpu := s.updateQuotaCPU
+	s.mutex.Unlock()
+
+	input := tview.NewInputField()
+	input.SetLabel("Memory quota (e.g. 2Gi, 512Mi, empty=unchanged): ")
+	input.SetFieldWidth(30)
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			mem := strings.TrimSpace(input.GetText())
+			s.hideUpdateQuotaPrompt()
+			s.promptUpdateQuotaVolumeDisk(cfg, uid, cpu, mem)
+		} else if key == tcell.KeyEscape {
+			s.hideUpdateQuotaPrompt()
+		}
+	})
+	s.setStatus("[yellow]Enter memory quota (or leave empty to keep current):[-]")
+	s.queueUpdate(func() {
+		s.statusContainer.Clear()
+		s.statusContainer.SetTitle("Update Quota (Memory)")
+		input.SetBorder(false)
+		s.statusContainer.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) promptUpdateQuotaVolumeDisk(cfg *cluster.Cluster, uid, cpu, mem string) {
+	s.mutex.Lock()
+	s.updateQuotaPromptVisible = true
+	s.mutex.Unlock()
+
+	input := tview.NewInputField()
+	input.SetLabel("Volume disk (e.g. 5Gi, empty=unchanged): ")
+	input.SetFieldWidth(30)
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			volDisk := strings.TrimSpace(input.GetText())
+			s.hideUpdateQuotaPrompt()
+			s.mutex.Lock()
+			s.updateQuotaVolumeDisk = volDisk
+			s.mutex.Unlock()
+			s.promptUpdateQuotaVolumeCount(cfg, uid, cpu, mem, volDisk)
+		} else if key == tcell.KeyEscape {
+			s.hideUpdateQuotaPrompt()
+		}
+	})
+	s.setStatus("[yellow]Enter volume disk quota (or leave empty to keep current):[-]")
+	s.queueUpdate(func() {
+		s.statusContainer.Clear()
+		s.statusContainer.SetTitle("Update Quota (Volume Disk)")
+		input.SetBorder(false)
+		s.statusContainer.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) promptUpdateQuotaVolumeCount(cfg *cluster.Cluster, uid, cpu, mem, volDisk string) {
+	s.mutex.Lock()
+	s.updateQuotaPromptVisible = true
+	s.mutex.Unlock()
+
+	input := tview.NewInputField()
+	input.SetLabel("Volume count (e.g. 3, empty=unchanged): ")
+	input.SetFieldWidth(30)
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			volCount := strings.TrimSpace(input.GetText())
+			s.hideUpdateQuotaPrompt()
+			s.performUpdateQuota(cfg, uid, cpu, mem, volDisk, volCount)
+		} else if key == tcell.KeyEscape {
+			s.hideUpdateQuotaPrompt()
+		}
+	})
+	s.setStatus("[yellow]Enter volume count quota (or leave empty to keep current):[-]")
+	s.queueUpdate(func() {
+		s.statusContainer.Clear()
+		s.statusContainer.SetTitle("Update Quota (Volume Count)")
+		input.SetBorder(false)
+		s.statusContainer.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) hideUpdateQuotaPrompt() {
+	s.mutex.Lock()
+	if !s.updateQuotaPromptVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.updateQuotaPromptVisible = false
+	focus := s.updateQuotaFocus
+	s.updateQuotaFocus = nil
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Status")
+		container.AddItem(s.statusView, 0, 1, false)
+		s.statusView.SetText(s.decorateStatusText(statusHelpText))
+	})
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
+}
+
+func (s *uiState) performUpdateQuota(cfg *cluster.Cluster, uid, cpu, mem, volDisk, volCount string) {
+	clusterName := s.currentCluster
+	s.setStatus(fmt.Sprintf("[yellow]Updating quota for user %q...", uid))
+	s.queueUpdate(func() {
+		s.detailsView.SetText(fmt.Sprintf("[yellow]Updating quota for user %q...[-]", uid))
+	})
+
+	var volUpdate *types.VolumeQuotaUpdate
+	if volDisk != "" || volCount != "" {
+		volUpdate = &types.VolumeQuotaUpdate{
+			Disk:    volDisk,
+			Volumes: volCount,
+		}
+	}
+
+	go func(name, userID, cpuVal, memVal string, vu *types.VolumeQuotaUpdate, clusterCfg *cluster.Cluster) {
+		defer func() {
+			if r := recover(); r != nil {
+				errMsg := fmt.Sprintf("unexpected error: %v", r)
+				s.setStatus(fmt.Sprintf("[red]Failed to update quota: %s", errMsg))
+				s.queueUpdate(func() {
+					s.detailsView.SetText(fmt.Sprintf("[red]Failed to update quota: %s[-]", errMsg))
+				})
+			}
+		}()
+		quota, err := cluster.UpdateQuota(clusterCfg, userID, cpuVal, memVal, vu)
+		if err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to update quota for %q: %v", userID, err))
+			s.queueUpdate(func() {
+				s.detailsView.SetText(fmt.Sprintf("[red]Failed to update quota for %q:\n%v[-]", userID, err))
+			})
+			return
+		}
+		s.setStatus(fmt.Sprintf("[green]Quota updated for user %q", userID))
+		text := formatQuota(name, quota)
+		s.queueUpdate(func() {
+			s.detailsView.SetText(text)
+		})
+	}(clusterName, uid, cpu, mem, volUpdate, cfg)
 }
 
 func formatClusterStatus(clusterName string, status cluster.StatusInfo) string {

--- a/pkg/tui/app.go
+++ b/pkg/tui/app.go
@@ -305,6 +305,21 @@ func (s *uiState) selectCluster(ctx context.Context, name string) {
 
 	s.showClusterDetails(name)
 
+	if mode == modeVolumes {
+		if name == "" {
+			s.setStatus("[red]Select a cluster to view volumes")
+			s.queueUpdate(func() {
+				s.showVolumeMessage("Select a cluster to view volumes")
+			})
+			return
+		}
+		s.queueUpdate(func() {
+			s.showVolumeMessage("Loading volumes…")
+		})
+		go s.loadVolumes(ctx, name, false)
+		return
+	}
+
 	if mode == modeBuckets {
 		if name == "" {
 			s.setStatus("[red]Select a cluster to view buckets")
@@ -348,7 +363,9 @@ func (s *uiState) refreshCurrent(ctx context.Context) {
 	if name == "" {
 		return
 	}
-	if mode == modeBuckets {
+	if mode == modeVolumes {
+		go s.loadVolumes(ctx, name, true)
+	} else if mode == modeBuckets {
 		go s.loadBuckets(ctx, name, true)
 	} else if mode == modeLogs {
 		go s.loadLogs(ctx, name, s.currentLogService, true)
@@ -385,6 +402,13 @@ func (s *uiState) modeIsBuckets() bool {
 	mode := s.mode
 	s.mutex.Unlock()
 	return mode == modeBuckets
+}
+
+func (s *uiState) modeIsVolumes() bool {
+	s.mutex.Lock()
+	mode := s.mode
+	s.mutex.Unlock()
+	return mode == modeVolumes
 }
 
 func (s *uiState) modeIsLogs() bool {
@@ -433,6 +457,10 @@ func (s *uiState) handleSelection(row int, immediate bool) {
 	s.mutex.Lock()
 	mode := s.mode
 	s.mutex.Unlock()
+	if mode == modeVolumes {
+		s.handleVolumeSelection(row, immediate)
+		return
+	}
 	if mode == modeBuckets {
 		s.handleBucketSelection(row, immediate)
 		return
@@ -475,6 +503,13 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 	if s.autoRefreshPromptVisible {
 		if event.Key() == tcell.KeyEsc {
 			s.hideAutoRefreshPrompt()
+			return nil
+		}
+		return event
+	}
+	if s.createVolumePromptVisible {
+		if event.Key() == tcell.KeyEsc {
+			s.hideCreateVolumePrompt()
 			return nil
 		}
 		return event
@@ -549,8 +584,16 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 	case 'w', 'W':
 		s.promptAutoRefresh()
 		return nil
+	case 'c', 'C':
+		if s.modeIsVolumes() {
+			s.promptCreateVolume()
+			return nil
+		}
 	case 'b', 'B':
 		s.switchToBuckets(ctx)
+		return nil
+	case 'm', 'M':
+		s.switchToVolumes(ctx)
 		return nil
 	case 's', 'S':
 		s.switchToServices(ctx)
@@ -577,7 +620,7 @@ func (s *uiState) handleInput(ctx context.Context, event *tcell.EventKey) *tcell
 			return nil
 		}
 	case 'd', 'D':
-		if s.app.GetFocus() == s.serviceTable && s.modeIsServices() {
+		if s.app.GetFocus() == s.serviceTable {
 			s.requestDeletion()
 			return nil
 		}

--- a/pkg/tui/bucket_objects.go
+++ b/pkg/tui/bucket_objects.go
@@ -3,10 +3,12 @@ package tui
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
 	"github.com/grycap/oscar-cli/pkg/storage"
@@ -339,5 +341,165 @@ func (s *uiState) fetchBucketObjects(ctx context.Context, clusterName, bucketNam
 	if activeKey == key {
 		s.renderBucketObjects(bucketName, state)
 		s.updateBucketObjectsStatus(bucketName, state)
+	}
+}
+
+func (s *uiState) currentBucketObjectSelection() (clusterName, bucketName, objectName string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.mode != modeBuckets {
+		return "", "", ""
+	}
+	clusterName = s.currentCluster
+	row, _ := s.serviceTable.GetSelection()
+	if row <= 0 || row-1 >= len(s.bucketInfos) {
+		return clusterName, "", ""
+	}
+	bucket := s.bucketInfos[row-1]
+	if bucket == nil {
+		return clusterName, "", ""
+	}
+	bucketName = bucket.Name
+	key := makeBucketObjectsKey(clusterName, bucketName)
+	state := s.bucketObjects[key]
+	if state == nil {
+		return clusterName, bucketName, ""
+	}
+	objRow, _ := s.bucketObjectsTable.GetSelection()
+	if objRow <= 0 || objRow-1 >= len(state.Objects) {
+		return clusterName, bucketName, ""
+	}
+	obj := state.Objects[objRow-1]
+	if obj == nil {
+		return clusterName, bucketName, ""
+	}
+	return clusterName, bucketName, obj.Name
+}
+
+func (s *uiState) requestBucketObjectDeletion() {
+	s.mutex.Lock()
+	if s.confirmVisible || s.legendVisible || s.pages == nil {
+		s.mutex.Unlock()
+		return
+	}
+	s.mutex.Unlock()
+
+	clusterName, bucketName, objectName := s.currentBucketObjectSelection()
+	if clusterName == "" || bucketName == "" || objectName == "" {
+		s.setStatus("[red]Select an object to delete")
+		return
+	}
+
+	prompt := fmt.Sprintf("Delete object %q from bucket %q?", objectName, bucketName)
+	s.queueUpdate(func() {
+		s.showConfirmation(prompt, func() {
+			go s.performBucketObjectDeletion(clusterName, bucketName, objectName)
+		})
+	})
+}
+
+func (s *uiState) performBucketObjectDeletion(clusterName, bucketName, objectName string) {
+	s.setStatus(fmt.Sprintf("[yellow]Deleting object %q...", objectName))
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+	remotePath := bucketName + "/" + objectName
+	if err := storage.DeleteFile(clusterCfg, storage.DefaultStorageProvider[0], remotePath); err != nil {
+		s.setStatus(fmt.Sprintf("[red]Failed to delete object %q: %v", objectName, err))
+		return
+	}
+	s.setStatus(fmt.Sprintf("[green]Object %q deleted", objectName))
+	s.reloadBucketObjects(context.Background())
+}
+
+func (s *uiState) promptPutFile() {
+	s.mutex.Lock()
+	if s.putFilePromptVisible || s.searchVisible || s.autoRefreshPromptVisible ||
+		s.confirmVisible || s.legendVisible || s.pages == nil {
+		s.mutex.Unlock()
+		return
+	}
+	s.putFilePromptVisible = true
+	s.putFileFocus = s.app.GetFocus()
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	input := tview.NewInputField().
+		SetLabel("Local file path: ").
+		SetFieldWidth(40)
+	input.SetDoneFunc(func(key tcell.Key) {
+		switch key {
+		case tcell.KeyEnter:
+			s.handlePutFilePath(strings.TrimSpace(input.GetText()))
+		case tcell.KeyEscape:
+			s.hidePutFilePrompt()
+		}
+	})
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Upload File")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) handlePutFilePath(localPath string) {
+	if localPath == "" {
+		s.setStatus("[red]File path cannot be empty")
+		return
+	}
+
+	s.hidePutFilePrompt()
+	s.setStatus(fmt.Sprintf("[yellow]Uploading %q...", localPath))
+
+	clusterName, bucketName, _ := s.currentBucketObjectSelection()
+	if clusterName == "" || bucketName == "" {
+		s.setStatus("[red]Select a bucket to upload to")
+		return
+	}
+
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+
+	remoteName := filepath.Base(localPath)
+	remotePath := bucketName + "/" + remoteName
+
+	go func() {
+		if err := storage.PutFile(clusterCfg, storage.DefaultStorageProvider[0], localPath, remotePath, &storage.TransferOption{ShowProgress: false}); err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to upload %q: %v", localPath, err))
+			return
+		}
+		s.setStatus(fmt.Sprintf("[green]Uploaded %q as %q", localPath, remoteName))
+		s.reloadBucketObjects(context.Background())
+	}()
+}
+
+func (s *uiState) hidePutFilePrompt() {
+	s.mutex.Lock()
+	if !s.putFilePromptVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.putFilePromptVisible = false
+	focus := s.putFileFocus
+	s.putFileFocus = nil
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Status")
+		container.AddItem(s.statusView, 0, 1, false)
+		s.statusView.SetText(s.decorateStatusText(statusHelpText))
+	})
+	if focus != nil {
+		s.app.SetFocus(focus)
 	}
 }

--- a/pkg/tui/buckets_view.go
+++ b/pkg/tui/buckets_view.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
 	"github.com/grycap/oscar-cli/pkg/storage"
@@ -251,4 +252,121 @@ func (s *uiState) searchBuckets(query string) bool {
 		}
 	}
 	return false
+}
+
+func (s *uiState) promptCreateBucket() {
+	s.mutex.Lock()
+	if s.createBucketPromptVisible || s.searchVisible || s.autoRefreshPromptVisible ||
+		s.confirmVisible || s.legendVisible || s.pages == nil ||
+		s.currentCluster == "" {
+		s.mutex.Unlock()
+		return
+	}
+	s.createBucketPromptVisible = true
+	s.createBucketName = ""
+	s.createBucketFocus = s.app.GetFocus()
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	input := tview.NewInputField().
+		SetLabel("Bucket name: ").
+		SetFieldWidth(30)
+	input.SetDoneFunc(func(key tcell.Key) {
+		switch key {
+		case tcell.KeyEnter:
+			s.handleCreateBucketName(strings.TrimSpace(input.GetText()))
+		case tcell.KeyEscape:
+			s.hideCreateBucketPrompt()
+		}
+	})
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Create Bucket")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) handleCreateBucketName(name string) {
+	if name == "" {
+		s.setStatus("[red]Bucket name cannot be empty")
+		return
+	}
+
+	s.mutex.Lock()
+	s.createBucketName = name
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	input := tview.NewInputField().
+		SetLabel("Visibility (public/private/restricted): ").
+		SetFieldWidth(20)
+	input.SetDoneFunc(func(key tcell.Key) {
+		switch key {
+		case tcell.KeyEnter:
+			s.handleCreateBucketVisibility(name, strings.TrimSpace(input.GetText()))
+		case tcell.KeyEscape:
+			s.hideCreateBucketPrompt()
+		}
+	})
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Create Bucket")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) handleCreateBucketVisibility(name, visibility string) {
+	if visibility == "" {
+		s.setStatus("[red]Visibility cannot be empty")
+		return
+	}
+
+	s.hideCreateBucketPrompt()
+	s.setStatus(fmt.Sprintf("[yellow]Creating bucket %q (%s)...", name, visibility))
+
+	clusterName := s.currentCluster
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+
+	go func() {
+		if err := storage.CreateBucket(clusterCfg, name, visibility, nil); err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to create bucket %q: %v", name, err))
+			return
+		}
+		s.setStatus(fmt.Sprintf("[green]Bucket %q created", name))
+		s.refreshCurrent(context.Background())
+	}()
+}
+
+func (s *uiState) hideCreateBucketPrompt() {
+	s.mutex.Lock()
+	if !s.createBucketPromptVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.createBucketPromptVisible = false
+	s.createBucketName = ""
+	focus := s.createBucketFocus
+	s.createBucketFocus = nil
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Status")
+		container.AddItem(s.statusView, 0, 1, false)
+		s.statusView.SetText(s.decorateStatusText(statusHelpText))
+	})
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
 }

--- a/pkg/tui/commands.go
+++ b/pkg/tui/commands.go
@@ -1,0 +1,231 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type commandEntry struct {
+	desc    string
+	handler func(args []string)
+}
+
+var commandRegistry = map[string]commandEntry{}
+
+func registerCommand(name, desc string, handler func(args []string)) {
+	commandRegistry[name] = commandEntry{desc: desc, handler: handler}
+}
+
+func init() {
+	// Commands are registered via init functions in each file
+}
+
+func (s *uiState) initCommands() {
+	registerCommand("help", "Show this help", func(args []string) {
+		s.toggleLegend()
+	})
+	registerCommand("refresh", "Refresh current view", func(args []string) {
+		s.refreshCurrent(s.rootCtx)
+	})
+	registerCommand("cluster.info", "Show cluster info", func(args []string) {
+		s.showClusterInfo()
+	})
+	registerCommand("cluster.status", "Show cluster status", func(args []string) {
+		s.showClusterStatus()
+	})
+	registerCommand("cluster.metrics", "Show cluster metrics", func(args []string) {
+		s.showMetricsSummary()
+	})
+	registerCommand("quota.get", "Get quota for a user [user]", func(args []string) {
+		s.showQuotaPrompt()
+	})
+	registerCommand("quota.update", "Update quota: [user] [cpu] [mem] [vol-disk] [vol-count]", func(args []string) {
+		if len(args) < 1 {
+			s.promptUpdateQuota()
+			return
+		}
+		userID := args[0]
+		cpu := argOr(args, 1, "")
+		mem := argOr(args, 2, "")
+		volDisk := argOr(args, 3, "")
+		volCount := argOr(args, 4, "")
+
+		s.mutex.Lock()
+		clusterCfg := s.conf.Oscar[s.currentCluster]
+		s.mutex.Unlock()
+		if clusterCfg == nil {
+			s.setStatus("[red]No cluster selected or cluster not found")
+			return
+		}
+		if clusterCfg.AuthUser == "" || clusterCfg.AuthPassword == "" {
+			s.setStatus("[red]Quota update is only available for clusters with auth_user/auth_password")
+			return
+		}
+		s.performUpdateQuota(clusterCfg, userID, cpu, mem, volDisk, volCount)
+	})
+	registerCommand("deploy.status", "Show deployment status <service>", func(args []string) {
+		s.showServiceDeploymentStatus(s.rootCtx)
+	})
+	registerCommand("deploy.logs", "Show deployment logs <service>", func(args []string) {
+		s.showServiceDeploymentLogs(s.rootCtx)
+	})
+	registerCommand("search", "Search <query>", func(args []string) {
+		s.initiateSearch(s.rootCtx)
+	})
+	registerCommand("services", "Switch to services view", func(args []string) {
+		s.switchToServices(s.rootCtx)
+	})
+	registerCommand("volumes", "Switch to volumes view", func(args []string) {
+		s.switchToVolumes(s.rootCtx)
+	})
+	registerCommand("volume.create", "Create a volume", func(args []string) {
+		s.mutex.Lock()
+		if s.mode != modeVolumes {
+			s.mutex.Unlock()
+			s.switchToVolumes(s.rootCtx)
+		} else {
+			s.mutex.Unlock()
+		}
+		s.promptCreateVolume()
+	})
+
+	registerCommand("buckets", "Switch to buckets view", func(args []string) {
+		s.switchToBuckets(s.rootCtx)
+	})
+	registerCommand("bucket.create", "Create a bucket", func(args []string) {
+		s.mutex.Lock()
+		if s.mode != modeBuckets {
+			s.mutex.Unlock()
+			s.switchToBuckets(s.rootCtx)
+		} else {
+			s.mutex.Unlock()
+		}
+		s.promptCreateBucket()
+	})
+}
+
+func argOr(args []string, idx int, def string) string {
+	if idx < len(args) {
+		return args[idx]
+	}
+	return def
+}
+
+func (s *uiState) showCommandPalette() {
+	s.mutex.Lock()
+	if s.commandPaletteVisible || s.searchVisible || s.autoRefreshPromptVisible ||
+		s.quotaPromptVisible || s.updateQuotaPromptVisible ||
+		s.confirmVisible || s.legendVisible || s.pages == nil {
+		s.mutex.Unlock()
+		return
+	}
+	s.commandPaletteVisible = true
+	s.commandPaletteFocus = s.app.GetFocus()
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.setStatus("[yellow]Enter command (Tab for suggestions):[-]")
+	input := tview.NewInputField()
+	input.SetLabel(": ")
+	input.SetFieldWidth(50)
+		input.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if (event.Key() == tcell.KeyBackspace || event.Key() == tcell.KeyBackspace2) && input.GetText() == "" {
+			s.hideCommandPalette()
+			return nil
+		}
+		return event
+	})
+	input.SetAutocompleteFunc(func(current string) []string {
+		current = strings.TrimSpace(current)
+		var suggestions []string
+		if current == "" {
+			suggestions = append(suggestions, "")
+		}
+		for name := range commandRegistry {
+			if current == "" || strings.HasPrefix(strings.ToLower(name), strings.ToLower(current)) {
+				displayName := strings.ReplaceAll(name, ".", " ")
+				suggestions = append(suggestions, displayName)
+			}
+		}
+		sort.Strings(suggestions)
+		return suggestions
+	})
+	input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			text := strings.TrimSpace(input.GetText())
+			s.hideCommandPalette()
+			if text != "" {
+				s.executeCommand(text)
+			}
+		} else if key == tcell.KeyEscape {
+			s.hideCommandPalette()
+		}
+	})
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Command Palette")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) hideCommandPalette() {
+	s.mutex.Lock()
+	if !s.commandPaletteVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.commandPaletteVisible = false
+	focus := s.commandPaletteFocus
+	s.commandPaletteFocus = nil
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Status")
+		container.AddItem(s.statusView, 0, 1, false)
+		s.statusView.SetText(s.decorateStatusText(statusHelpText))
+	})
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
+}
+
+func (s *uiState) executeCommand(input string) {
+	parts := strings.Fields(input)
+	if len(parts) == 0 {
+		return
+	}
+
+	// Normalize: replace spaces with dots for matching (user types "quota get", registry has "quota.get")
+	normalized := strings.ToLower(strings.ReplaceAll(input, " ", "."))
+
+	var bestMatch string
+	var bestEntry commandEntry
+	bestLen := 0
+
+	for name, entry := range commandRegistry {
+		lowerName := strings.ToLower(name)
+		if strings.HasPrefix(normalized, lowerName) && len(lowerName) > bestLen {
+			bestMatch = name
+			bestEntry = entry
+			bestLen = len(lowerName)
+		}
+	}
+
+	if bestLen > 0 {
+		cmdParts := strings.Split(bestMatch, ".")
+		args := parts[len(cmdParts):]
+		bestEntry.handler(args)
+		return
+	}
+
+	s.setStatus(fmt.Sprintf("[red]Unknown command: %q. Type 'help' for available commands", parts[0]))
+}

--- a/pkg/tui/dialogs.go
+++ b/pkg/tui/dialogs.go
@@ -122,6 +122,27 @@ func (s *uiState) requestDeletion() {
 				go s.performBucketDeletion(clusterName, bucketName)
 			})
 		})
+	case modeVolumes:
+		if row <= 0 || row-1 >= len(s.volumes) || clusterName == "" {
+			s.mutex.Unlock()
+			s.setStatus("[red]Select a volume to delete")
+			return
+		}
+		vol := s.volumes[row-1]
+		if strings.TrimSpace(vol.Name) == "" {
+			s.mutex.Unlock()
+			s.setStatus("[red]Select a volume to delete")
+			return
+		}
+		volName := vol.Name
+		s.mutex.Unlock()
+
+		prompt := fmt.Sprintf("Delete volume %q from cluster %q?", volName, clusterName)
+		s.queueUpdate(func() {
+			s.showConfirmation(prompt, func() {
+				go s.performVolumeDeletion(clusterName, volName)
+			})
+		})
 	default:
 		s.mutex.Unlock()
 		s.setStatus("[red]Deletion not available in this view")

--- a/pkg/tui/dialogs.go
+++ b/pkg/tui/dialogs.go
@@ -7,6 +7,59 @@ import (
 	"github.com/rivo/tview"
 )
 
+func legendTextForMode(mode panelMode) string {
+	base := `[yellow]Navigation[-]
+  ↑/↓  Move selection
+  ←/→ or Tab  Switch pane
+  f  Focus details panel
+
+[yellow]General[-]
+  q  Quit
+  r  Refresh current view
+  w  Configure auto refresh
+  ?  Toggle this help
+  :  Command palette
+  /  Search
+  i  Show cluster info
+  e  Show cluster status
+  m  Show cluster metrics
+  b  Switch to buckets view
+  s  Switch to services view
+  v  Switch to volumes view
+
+[yellow]Mode-specific[-]
+`
+	switch mode {
+	case modeServices:
+		base += `  d  Delete selected service
+  l  Open logs panel
+  g  Get quota (prompts user ID)
+  k  Update quota (5-step wizard)
+  t  Show deployment status
+  h  Show deployment logs
+  Enter  Focus service
+`
+	case modeVolumes:
+		base += `  c  Create volume
+  d  Delete selected volume
+`
+	case modeBuckets:
+		base += `  c  Create bucket
+  d  Delete selected bucket
+  Enter  Focus bucket objects
+  u  Upload file (in objects view)
+  o  Reload bucket objects
+  n/p  Next/previous page
+  a  Load all objects
+`
+	case modeLogs:
+		base += `  l  Open logs panel
+  d  Delete log
+`
+	}
+	return base
+}
+
 func (s *uiState) toggleLegend() {
 	s.mutex.Lock()
 	visible := s.legendVisible
@@ -37,9 +90,10 @@ func (s *uiState) showLegendUnlocked() {
 	}
 	s.legendVisible = true
 	s.savedFocus = s.app.GetFocus()
+	mode := s.mode
 	s.mutex.Unlock()
 	modal := tview.NewModal().
-		SetText(legendText).
+		SetText(legendTextForMode(mode)).
 		AddButtons([]string{"Close"})
 	modal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 		s.hideLegendUnlocked()

--- a/pkg/tui/formatters.go
+++ b/pkg/tui/formatters.go
@@ -358,3 +358,67 @@ func formatQuota(name string, quota *types.QuotaResponse) string {
 
 	return strings.TrimRight(builder.String(), "\n")
 }
+
+func formatDeploymentStatus(name string, ds *types.ServiceDeploymentSummary) string {
+	if ds == nil {
+		return "No deployment data available"
+	}
+	builder := &strings.Builder{}
+	fmt.Fprintf(builder, "[yellow]Service:[-] %s\n", name)
+
+	color := "[green]"
+	switch ds.State {
+	case types.DeploymentStateReady:
+		color = "[green]"
+	case types.DeploymentStateDegraded:
+		color = "[yellow]"
+	case types.DeploymentStateFailed, types.DeploymentStateUnavailable:
+		color = "[red]"
+	default:
+		color = "[blue]"
+	}
+	fmt.Fprintf(builder, "[yellow]State:[-] %s%s[-]\n", color, ds.State)
+
+	if ds.Reason != "" {
+		fmt.Fprintf(builder, "[yellow]Reason:[-] %s\n", ds.Reason)
+	}
+
+	if ds.LastTransitionTime != nil {
+		fmt.Fprintf(builder, "[yellow]Last Transition:[-] %s\n", ds.LastTransitionTime.Time.Format("2006-01-02 15:04:05"))
+	}
+
+	if ds.ActiveInstances > 0 || ds.AffectedInstances > 0 {
+		fmt.Fprintf(builder, "[yellow]Active Instances:[-] %d\n", ds.ActiveInstances)
+		fmt.Fprintf(builder, "[yellow]Affected Instances:[-] %d\n", ds.AffectedInstances)
+	}
+
+	if ds.ResourceKind != "" {
+		fmt.Fprintf(builder, "[yellow]Resource Kind:[-] %s\n", ds.ResourceKind)
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func formatDeploymentLogs(dl *types.DeploymentLogStream) string {
+	if dl == nil {
+		return "No deployment logs available"
+	}
+	builder := &strings.Builder{}
+	fmt.Fprintf(builder, "[yellow]Service:[-] %s\n", dl.ServiceName)
+	fmt.Fprintf(builder, "[yellow]Available:[-] %t\n", dl.Available)
+	if dl.Message != "" {
+		fmt.Fprintf(builder, "[yellow]Message:[-] %s\n", dl.Message)
+	}
+	if len(dl.Entries) > 0 {
+		builder.WriteString("\n[yellow]Entries:[-]\n")
+		for _, e := range dl.Entries {
+			if e.Timestamp != "" {
+				fmt.Fprintf(builder, "  %s  ", e.Timestamp)
+			} else {
+				builder.WriteString("  ")
+			}
+			fmt.Fprintf(builder, "%s\n", e.Message)
+		}
+	}
+	return strings.TrimRight(builder.String(), "\n")
+}

--- a/pkg/tui/formatters.go
+++ b/pkg/tui/formatters.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -298,4 +299,62 @@ func formatVolumeDetails(vol *types.ManagedVolume) string {
 	}
 
 	return builder.String()
+}
+
+func formatQuota(name string, quota *types.QuotaResponse) string {
+	if quota == nil {
+		return "No quota data available"
+	}
+	builder := &strings.Builder{}
+	if name != "" {
+		fmt.Fprintf(builder, "[yellow]Cluster:[-] %s\n", name)
+	}
+	fmt.Fprintf(builder, "[yellow]User:[-] %s\n", defaultIfEmpty(quota.UserID, "-"))
+	if quota.ClusterQueue != "" {
+		fmt.Fprintf(builder, "[yellow]Cluster Queue:[-] %s\n", quota.ClusterQueue)
+	}
+
+	// Sort resource keys for consistent output
+	resKeys := make([]string, 0, len(quota.Resources))
+	for k := range quota.Resources {
+		resKeys = append(resKeys, k)
+	}
+	sort.Strings(resKeys)
+
+	if len(resKeys) > 0 {
+		builder.WriteString("\n[yellow]Resources[-]\n")
+		for _, k := range resKeys {
+			v := quota.Resources[k]
+			colorMax := "[green]"
+			colorUsed := "[green]"
+			if v.Max > 0 && v.Used >= v.Max {
+				colorUsed = "[red]"
+			} else if v.Max > 0 && v.Used > v.Max/2 {
+				colorUsed = "[yellow]"
+			}
+			fmt.Fprintf(builder, "  %s: %s%d[-] / %s%d[-]\n", k, colorUsed, v.Used, colorMax, v.Max)
+		}
+	}
+
+	if v := quota.Volumes; v != nil {
+		builder.WriteString("\n[yellow]Volumes[-]\n")
+		if v.Disk.Max != "" || v.Disk.Used != "" {
+			fmt.Fprintf(builder, "  Disk:    %s / %s\n",
+				defaultIfEmpty(v.Disk.Used, "0"),
+				defaultIfEmpty(v.Disk.Max, "-"))
+		}
+		if v.Volumes.Max != "" || v.Volumes.Used != "" {
+			fmt.Fprintf(builder, "  Count:   %s / %s\n",
+				defaultIfEmpty(v.Volumes.Used, "0"),
+				defaultIfEmpty(v.Volumes.Max, "-"))
+		}
+		if v.MaxDiskperVolume != "" {
+			fmt.Fprintf(builder, "  Max/vol: %s\n", v.MaxDiskperVolume)
+		}
+		if v.MinDiskperVolume != "" {
+			fmt.Fprintf(builder, "  Min/vol: %s\n", v.MinDiskperVolume)
+		}
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
 }

--- a/pkg/tui/formatters.go
+++ b/pkg/tui/formatters.go
@@ -181,3 +181,50 @@ func formatBucketDetails(bucket *storage.BucketInfo) string {
 
 	return builder.String()
 }
+
+func formatVolumeDetails(vol *types.ManagedVolume) string {
+	if vol == nil {
+		return ""
+	}
+	builder := &strings.Builder{}
+	fmt.Fprintf(builder, "[yellow]Name:[-] %s\n", vol.Name)
+	if vol.Size != "" {
+		fmt.Fprintf(builder, "[yellow]Size:[-] %s\n", vol.Size)
+	}
+	if vol.Status.Phase != "" {
+		colorTag := colorTagForPhase(vol.Status.Phase)
+		fmt.Fprintf(builder, "[yellow]Status:[-] %s%s[-]\n", colorTag, vol.Status.Phase)
+	}
+	if vol.Status.Message != "" {
+		fmt.Fprintf(builder, "[yellow]Message:[-] %s\n", vol.Status.Message)
+	}
+	if vol.Namespace != "" {
+		fmt.Fprintf(builder, "[yellow]Namespace:[-] %s\n", vol.Namespace)
+	}
+	if vol.PVCName != "" {
+		fmt.Fprintf(builder, "[yellow]PVC Name:[-] %s\n", vol.PVCName)
+	}
+	if vol.OwnerUser != "" {
+		fmt.Fprintf(builder, "[yellow]Owner:[-] %s\n", vol.OwnerUser)
+	}
+	if vol.CreationMode != "" {
+		fmt.Fprintf(builder, "[yellow]Creation Mode:[-] %s\n", vol.CreationMode)
+	}
+	if vol.LifecyclePolicy != "" {
+		fmt.Fprintf(builder, "[yellow]Lifecycle Policy:[-] %s\n", vol.LifecyclePolicy)
+	}
+	if vol.CreatedByService != "" {
+		fmt.Fprintf(builder, "[yellow]Created By:[-] %s\n", vol.CreatedByService)
+	}
+	if len(vol.Attachments) > 0 {
+		fmt.Fprintf(builder, "[yellow]Attachments:[-]\n")
+		for _, att := range vol.Attachments {
+			fmt.Fprintf(builder, "  - %s → %s\n", att.ServiceName, att.MountPath)
+		}
+	}
+	if vol.Status.AttachmentCount > 0 {
+		fmt.Fprintf(builder, "[yellow]Attachment Count:[-] %d\n", vol.Status.AttachmentCount)
+	}
+
+	return builder.String()
+}

--- a/pkg/tui/formatters.go
+++ b/pkg/tui/formatters.go
@@ -182,6 +182,77 @@ func formatBucketDetails(bucket *storage.BucketInfo) string {
 	return builder.String()
 }
 
+func formatMetricsSummary(name string, summary *types.MetricsSummaryResponse) string {
+	if summary == nil {
+		return "No metrics available"
+	}
+	builder := &strings.Builder{}
+	if name != "" {
+		fmt.Fprintf(builder, "[yellow]Cluster:[-] %s\n", name)
+	}
+	if !summary.Start.IsZero() && !summary.End.IsZero() {
+		fmt.Fprintf(builder, "[yellow]Period:[-] %s → %s\n",
+			summary.Start.Format("2006-01-02 15:04"),
+			summary.End.Format("2006-01-02 15:04"))
+	}
+
+	totals := summary.Totals
+	builder.WriteString("\n[yellow]Services[-]\n")
+	fmt.Fprintf(builder, "  Active: %d\n", totals.ServicesCountActive)
+	fmt.Fprintf(builder, "  Total:  %d\n", totals.ServicesCountTotal)
+
+	builder.WriteString("\n[yellow]CPU/GPU Hours[-]\n")
+	fmt.Fprintf(builder, "  CPU: %.1f h\n", totals.CPUHoursTotal)
+	fmt.Fprintf(builder, "  GPU: %.1f h\n", totals.GPUHoursTotal)
+
+	builder.WriteString("\n[yellow]Requests[-]\n")
+	fmt.Fprintf(builder, "  Total:  %d\n", totals.RequestsCountTotal)
+	fmt.Fprintf(builder, "  Sync:   %d\n", totals.RequestsCountSync)
+	fmt.Fprintf(builder, "  Async:  %d\n", totals.RequestsCountAsync)
+	fmt.Fprintf(builder, "  Exposed: %d\n", totals.RequestsCountExposed)
+
+	builder.WriteString("\n[yellow]Users[-]\n")
+	fmt.Fprintf(builder, "  Total: %d\n", totals.UsersCount)
+	if len(totals.Users) > 0 {
+		builder.WriteString("  ")
+		for i, u := range totals.Users {
+			if i > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteString(u)
+		}
+		builder.WriteByte('\n')
+	}
+
+	builder.WriteString("\n[yellow]Countries[-]\n")
+	fmt.Fprintf(builder, "  Total: %d\n", totals.CountriesCount)
+	if len(totals.Countries) > 0 {
+		for _, c := range totals.Countries {
+			fmt.Fprintf(builder, "  - %s: %d\n", c.Country, c.RequestCount)
+		}
+	}
+
+	if len(summary.Sources) > 0 {
+		builder.WriteString("\n[yellow]Sources[-]\n")
+		for _, src := range summary.Sources {
+			statusColor := "[green]"
+			if src.Status != "healthy" {
+				statusColor = "[red]"
+			}
+			fmt.Fprintf(builder, "  - %s: %s%s[-]", src.Name, statusColor, src.Status)
+			if src.LastUpdated != nil && !src.LastUpdated.IsZero() {
+				fmt.Fprintf(builder, " (%s)", src.LastUpdated.Format("2006-01-02 15:04"))
+			}
+			builder.WriteByte('\n')
+			if src.Notes != "" {
+				fmt.Fprintf(builder, "    %s\n", src.Notes)
+			}
+		}
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
+}
+
 func formatVolumeDetails(vol *types.ManagedVolume) string {
 	if vol == nil {
 		return ""

--- a/pkg/tui/search.go
+++ b/pkg/tui/search.go
@@ -35,6 +35,20 @@ func (s *uiState) initiateSearch(ctx context.Context) {
 		}
 	case s.detailsView:
 		target = searchTargetDetails
+	case s.bucketObjectsTable:
+		target = searchTargetBuckets
+	}
+
+	// If focus is on the cluster list but we're in a mode-specific view,
+	// search that view's data instead.
+	if target == searchTargetClusters {
+		if mode == modeBuckets {
+			target = searchTargetBuckets
+		} else if mode == modeVolumes {
+			target = searchTargetVolumes
+		} else if mode == modeServices {
+			target = searchTargetServices
+		}
 	}
 
 	if target == searchTargetNone && len(s.clusterNames) > 0 {

--- a/pkg/tui/search.go
+++ b/pkg/tui/search.go
@@ -28,6 +28,8 @@ func (s *uiState) initiateSearch(ctx context.Context) {
 			target = searchTargetBuckets
 		} else if mode == modeLogs {
 			target = searchTargetLogs
+		} else if mode == modeVolumes {
+			target = searchTargetVolumes
 		} else {
 			target = searchTargetServices
 		}
@@ -69,6 +71,12 @@ func (s *uiState) initiateSearch(ctx context.Context) {
 			s.setStatus("[yellow]No buckets to search")
 			return
 		}
+	case searchTargetVolumes:
+		if len(s.volumes) == 0 {
+			s.mutex.Unlock()
+			s.setStatus("[yellow]No volumes to search")
+			return
+		}
 	case searchTargetDetails:
 		text := s.detailsView.GetText(true)
 		if strings.TrimSpace(text) == "" {
@@ -102,6 +110,8 @@ func (s *uiState) showSearch(target searchTarget) {
 		label = "Services: "
 	case searchTargetBuckets:
 		label = "Buckets: "
+	case searchTargetVolumes:
+		label = "Volumes: "
 	case searchTargetDetails:
 		label = "Details: "
 	}
@@ -178,6 +188,8 @@ func (s *uiState) handleSearchInput(query string) {
 		found = s.searchLogs(lower)
 	case searchTargetBuckets:
 		found = s.searchBuckets(lower)
+	case searchTargetVolumes:
+		found = s.searchVolumes(lower)
 	case searchTargetDetails:
 		found = s.searchDetails(lower)
 	}

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -37,7 +37,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]g[::-] Quota · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]g[::-] Quota · [::b]k[::-] Update quota · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 
@@ -110,6 +110,15 @@ type uiState struct {
 	createBucketFocus        tview.Primitive
 	putFilePromptVisible     bool
 	putFileFocus             tview.Primitive
+	quotaPromptVisible       bool
+	quotaFocus               tview.Primitive
+	updateQuotaPromptVisible bool
+	updateQuotaStep          int
+	updateQuotaUserID        string
+	updateQuotaCPU           string
+	updateQuotaVolumeDisk    string
+	updateQuotaVolumeCount   string
+	updateQuotaFocus         tview.Primitive
 	bucketInfos              []*storage.BucketInfo
 	bucketCancel             context.CancelFunc
 	bucketSeq                int

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -19,14 +19,15 @@ const legendText = `[yellow]Navigation[-]
 
 [yellow]Actions[-]
   r  Refresh current view
-  d or Del  Delete selected service/bucket/volume
+  d or Del  Delete selected service/bucket/volume/object
   i  Show cluster info
   l  Open logs panel
   w  Configure auto refresh
   b  Switch to buckets view
   s  Switch to services view
   m  Switch to volumes view
-  c  Create volume (volumes view)
+  c  Create bucket/volume
+  u  Upload file (bucket objects view)
   Enter  Focus bucket objects (bucket view)
   o  Reload bucket objects (bucket view)
   n/p  Next/previous bucket objects page
@@ -34,7 +35,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]m[::-] Volumes · [::b]c[::-] Create volume · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]m[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 
@@ -102,6 +103,11 @@ type uiState struct {
 	createVolumePromptVisible bool
 	createVolumeName         string
 	createVolumeFocus        tview.Primitive
+	createBucketPromptVisible bool
+	createBucketName         string
+	createBucketFocus        tview.Primitive
+	putFilePromptVisible     bool
+	putFileFocus             tview.Primitive
 	bucketInfos              []*storage.BucketInfo
 	bucketCancel             context.CancelFunc
 	bucketSeq                int

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -19,12 +19,14 @@ const legendText = `[yellow]Navigation[-]
 
 [yellow]Actions[-]
   r  Refresh current view
-  d or Del  Delete selected service/bucket
+  d or Del  Delete selected service/bucket/volume
   i  Show cluster info
   l  Open logs panel
   w  Configure auto refresh
   b  Switch to buckets view
   s  Switch to services view
+  m  Switch to volumes view
+  c  Create volume (volumes view)
   Enter  Focus bucket objects (bucket view)
   o  Reload bucket objects (bucket view)
   n/p  Next/previous bucket objects page
@@ -32,7 +34,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]m[::-] Volumes · [::b]c[::-] Create volume · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 
@@ -40,6 +42,7 @@ const (
 	modeServices panelMode = iota
 	modeBuckets
 	modeLogs
+	modeVolumes
 )
 
 var (
@@ -47,6 +50,7 @@ var (
 	bucketHeaders       = []string{"Name", "Visibility", "Owner"}
 	bucketObjectHeaders = []string{"Name", "Size (B)", "Last Modified"}
 	logHeaders          = []string{"Job", "Status", "Started", "Finished"}
+	volumeHeaders       = []string{"Name", "Size", "Status", "Attachments"}
 )
 
 type searchTarget int
@@ -57,6 +61,7 @@ const (
 	searchTargetServices
 	searchTargetLogs
 	searchTargetBuckets
+	searchTargetVolumes
 	searchTargetDetails
 )
 
@@ -90,6 +95,13 @@ type uiState struct {
 	confirmVisible           bool
 	savedFocus               tview.Primitive
 	mode                     panelMode
+	volumes                  []types.ManagedVolume
+	volumeCancel             context.CancelFunc
+	volumeSeq                int
+	volumeCluster            string
+	createVolumePromptVisible bool
+	createVolumeName         string
+	createVolumeFocus        tview.Primitive
 	bucketInfos              []*storage.BucketInfo
 	bucketCancel             context.CancelFunc
 	bucketSeq                int

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -37,7 +37,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]g[::-] Quota · [::b]k[::-] Update quota · [::b]t[::-] Deploy status · [::b]h[::-] Deploy logs · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]g[::-] Quota · [::b]k[::-] Update quota · [::b]t[::-] Deploy status · [::b]h[::-] Deploy logs · [::b]::[::-] Command palette · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 
@@ -119,6 +119,8 @@ type uiState struct {
 	updateQuotaVolumeDisk    string
 	updateQuotaVolumeCount   string
 	updateQuotaFocus         tview.Primitive
+	commandPaletteVisible    bool
+	commandPaletteFocus      tview.Primitive
 	bucketInfos              []*storage.BucketInfo
 	bucketCancel             context.CancelFunc
 	bucketSeq                int

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -37,7 +37,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]g[::-] Quota · [::b]k[::-] Update quota · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]g[::-] Quota · [::b]k[::-] Update quota · [::b]t[::-] Deploy status · [::b]h[::-] Deploy logs · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -15,7 +15,7 @@ import (
 const legendText = `[yellow]Navigation[-]
   ↑/↓  Move selection
   ←/→ or Tab  Switch pane
-  v  Focus details panel
+  f  Focus details panel
 
 [yellow]Actions[-]
   r  Refresh current view
@@ -25,9 +25,11 @@ const legendText = `[yellow]Navigation[-]
   w  Configure auto refresh
   b  Switch to buckets view
   s  Switch to services view
-  m  Switch to volumes view
+  v  Switch to volumes view
   c  Create bucket/volume
   u  Upload file (bucket objects view)
+  m  Show cluster metrics
+  e  Show cluster status
   Enter  Focus bucket objects (bucket view)
   o  Reload bucket objects (bucket view)
   n/p  Next/previous bucket objects page
@@ -35,7 +37,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]m[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]v[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 

--- a/pkg/tui/state.go
+++ b/pkg/tui/state.go
@@ -37,7 +37,7 @@ const legendText = `[yellow]Navigation[-]
   q  Quit
   ?  Toggle this help`
 
-const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
+const statusHelpText = "[yellow]Keys: [::b]q[::-] Quit · [::b]r[::-] Refresh · [::b]d/Del[::-] Delete svc/bucket/volume/object · [::b]i[::-] Cluster info · [::b]l[::-] Logs panel · [::b]w[::-] Auto refresh · [::b]b[::-] Buckets · [::b]s[::-] Services · [::b]v[::-] Volumes · [::b]c[::-] Create bucket/volume · [::b]u[::-] Upload file · [::b]m[::-] Metrics · [::b]e[::-] Status · [::b]g[::-] Quota · [::b]f[::-] Focus details · [::b]Enter/n/p/a/o[::-] Bucket objects · [::b]?[::-] Help · [::b]←/→[::-] Switch pane · [::b]/[::-] Search"
 
 type panelMode int
 

--- a/pkg/tui/table_helpers.go
+++ b/pkg/tui/table_helpers.go
@@ -19,6 +19,10 @@ func setBucketTableHeader(table *tview.Table) {
 	setTableHeader(table, bucketHeaders)
 }
 
+func setVolumeTableHeader(table *tview.Table) {
+	setTableHeader(table, volumeHeaders)
+}
+
 func setBucketObjectTableHeader(table *tview.Table) {
 	setTableHeader(table, bucketObjectHeaders)
 }
@@ -53,5 +57,35 @@ func bucketVisibilityColor(vis string) tcell.Color {
 		return tcell.ColorGreen
 	default:
 		return tcell.ColorWhite
+	}
+}
+
+func volumePhaseColor(phase string) tcell.Color {
+	switch strings.ToLower(strings.TrimSpace(phase)) {
+	case "ready", "in_use":
+		return tcell.ColorGreen
+	case "pending":
+		return tcell.ColorYellow
+	case "error":
+		return tcell.ColorRed
+	case "deleting", "deleted":
+		return tcell.ColorDarkCyan
+	default:
+		return tcell.ColorWhite
+	}
+}
+
+func colorTagForPhase(phase string) string {
+	switch strings.ToLower(strings.TrimSpace(phase)) {
+	case "ready", "in_use":
+		return "[green]"
+	case "pending":
+		return "[yellow]"
+	case "error":
+		return "[red]"
+	case "deleting", "deleted":
+		return "[gray]"
+	default:
+		return "[white]"
 	}
 }

--- a/pkg/tui/volumes_view.go
+++ b/pkg/tui/volumes_view.go
@@ -1,0 +1,373 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/grycap/oscar-cli/pkg/volume"
+	"github.com/grycap/oscar/v4/pkg/types"
+)
+
+func (s *uiState) switchToVolumes(ctx context.Context) {
+	if s.searchVisible {
+		s.hideSearch()
+	}
+	s.mutex.Lock()
+	if s.confirmVisible || s.legendVisible {
+		s.mutex.Unlock()
+		return
+	}
+	if s.mode == modeVolumes {
+		s.mutex.Unlock()
+		return
+	}
+	s.mode = modeVolumes
+	if s.loadCancel != nil {
+		s.loadCancel()
+		s.loadCancel = nil
+		s.refreshing = false
+		s.loadingCluster = ""
+	}
+	if s.bucketCancel != nil {
+		s.bucketCancel()
+		s.bucketCancel = nil
+	}
+	if s.bucketObjectsCancel != nil {
+		s.bucketObjectsCancel()
+		s.bucketObjectsCancel = nil
+	}
+	if s.detailTimer != nil {
+		s.detailTimer.Stop()
+		s.detailTimer = nil
+	}
+	s.lastSelection = ""
+	s.currentBucketObjectsKey = ""
+	s.mutex.Unlock()
+
+	s.hideBucketObjectsPane()
+
+	clusterName := s.currentCluster
+	if clusterName == "" {
+		s.setStatus("[red]Select a cluster to view volumes")
+		s.queueUpdate(func() {
+			s.showVolumeMessage("Select a cluster to view volumes")
+		})
+		s.showClusterDetails(clusterName)
+		return
+	}
+
+	s.showClusterDetails(clusterName)
+	s.queueUpdate(func() {
+		s.showVolumeMessage("Loading volumes…")
+	})
+
+	s.mutex.Lock()
+	cached := s.volumes
+	cachedCluster := s.volumeCluster
+	s.mutex.Unlock()
+	if len(cached) > 0 && cachedCluster == clusterName {
+		s.renderVolumeTable(cached)
+		s.setStatus(fmt.Sprintf("[green]Loaded %d volume(s) for %s", len(cached), clusterName))
+		return
+	}
+
+	go s.loadVolumes(ctx, clusterName, false)
+}
+
+func (s *uiState) loadVolumes(ctx context.Context, name string, force bool) {
+	if name == "" {
+		return
+	}
+
+	clusterCfg := s.conf.Oscar[name]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", name))
+		s.queueUpdate(func() {
+			s.showVolumeMessage("Cluster not found")
+		})
+		return
+	}
+
+	s.setStatus(fmt.Sprintf("[yellow]Loading volumes for cluster %s…", name))
+	s.mutex.Lock()
+	keepTable := force && s.currentCluster == name && len(s.volumes) > 0
+	s.mutex.Unlock()
+	if !keepTable {
+		s.queueUpdate(func() {
+			s.showVolumeMessage("Loading volumes…")
+		})
+	}
+
+	s.mutex.Lock()
+	if s.volumeCancel != nil {
+		s.volumeCancel()
+		s.volumeCancel = nil
+	}
+	s.volumeSeq++
+	seq := s.volumeSeq
+	s.mutex.Unlock()
+
+	vols, err := volume.ListVolumes(clusterCfg)
+	if err != nil {
+		s.setStatus(fmt.Sprintf("[red]Unable to load volumes for %s: %v", name, err))
+		s.mutex.Lock()
+		if seq == s.volumeSeq {
+			s.volumes = nil
+			s.volumeCancel = nil
+			s.volumeCluster = ""
+		}
+		s.mutex.Unlock()
+		s.queueUpdate(func() {
+			s.showVolumeMessage("Unable to load volumes")
+		})
+		return
+	}
+
+	s.mutex.Lock()
+	if seq != s.volumeSeq {
+		s.mutex.Unlock()
+		return
+	}
+	s.volumes = vols
+	s.volumeCancel = nil
+	s.volumeCluster = name
+	mode := s.mode
+	currentCluster := s.currentCluster
+	s.mutex.Unlock()
+
+	if mode == modeVolumes && currentCluster == name {
+		s.renderVolumeTable(vols)
+		s.setStatus(fmt.Sprintf("[green]Loaded %d volume(s) for %s", len(vols), name))
+	}
+}
+
+func (s *uiState) handleVolumeSelection(row int, immediate bool) {
+	s.mutex.Lock()
+	if s.mode != modeVolumes {
+		s.mutex.Unlock()
+		return
+	}
+	var vol *types.ManagedVolume
+	if row > 0 && row-1 < len(s.volumes) {
+		vol = &s.volumes[row-1]
+	}
+	s.mutex.Unlock()
+
+	if vol == nil {
+		s.queueUpdate(func() {
+			s.detailsView.SetText("Select a volume to inspect details")
+		})
+		return
+	}
+
+	s.queueUpdate(func() {
+		s.detailsView.SetText(formatVolumeDetails(vol))
+	})
+}
+
+func (s *uiState) renderVolumeTable(vols []types.ManagedVolume) {
+	s.queueUpdate(func() {
+		s.serviceTable.SetTitle("Volumes")
+		setVolumeTableHeader(s.serviceTable)
+		if len(vols) == 0 {
+			fillMessageRow(s.serviceTable, len(volumeHeaders), "No volumes found")
+			s.detailsView.SetText("Select a volume to inspect details")
+			return
+		}
+		for i, vol := range vols {
+			row := i + 1
+			color := volumePhaseColor(vol.Status.Phase)
+			attachments := "0"
+			if vol.Status.AttachmentCount > 0 {
+				attachments = fmt.Sprintf("%d", vol.Status.AttachmentCount)
+			}
+			nameCell := tview.NewTableCell(vol.Name).
+				SetSelectable(true).
+				SetExpansion(4)
+			sizeCell := tview.NewTableCell(defaultIfEmpty(vol.Size, "-")).
+				SetExpansion(2)
+			statusCell := tview.NewTableCell(defaultIfEmpty(vol.Status.Phase, "-")).
+				SetExpansion(2).
+				SetTextColor(color)
+			attCell := tview.NewTableCell(attachments).
+				SetExpansion(2)
+			s.serviceTable.SetCell(row, 0, nameCell).
+				SetCell(row, 1, sizeCell).
+				SetCell(row, 2, statusCell).
+				SetCell(row, 3, attCell)
+		}
+		row, col := s.serviceTable.GetSelection()
+		if row <= 0 || row > len(vols) {
+			s.serviceTable.Select(1, 0)
+		} else {
+			s.serviceTable.Select(row, col)
+		}
+	})
+}
+
+func (s *uiState) showVolumeMessage(message string) {
+	s.serviceTable.SetTitle("Volumes")
+	setVolumeTableHeader(s.serviceTable)
+	fillMessageRow(s.serviceTable, len(volumeHeaders), message)
+}
+
+func (s *uiState) performVolumeDeletion(clusterName, volumeName string) {
+	s.setStatus(fmt.Sprintf("[yellow]Deleting volume %q...", volumeName))
+	s.mutex.Lock()
+	s.lastSelection = ""
+	s.mutex.Unlock()
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+	if err := volume.DeleteVolume(clusterCfg, volumeName); err != nil {
+		s.setStatus(fmt.Sprintf("[red]Failed to delete volume %q: %v", volumeName, err))
+		return
+	}
+	s.setStatus(fmt.Sprintf("[green]Volume %q deleted", volumeName))
+	s.queueUpdate(func() {
+		s.detailsView.SetText("Select a volume to inspect details")
+	})
+	s.refreshCurrent(context.Background())
+}
+
+func (s *uiState) searchVolumes(query string) bool {
+	s.mutex.Lock()
+	vols := append([]types.ManagedVolume(nil), s.volumes...)
+	s.mutex.Unlock()
+	for idx, vol := range vols {
+		haystack := strings.ToLower(vol.Name + " " + vol.Size + " " + vol.Status.Phase)
+		if strings.Contains(haystack, query) {
+			row := idx + 1
+			s.queueUpdate(func() {
+				s.serviceTable.Select(row, 0)
+				s.handleVolumeSelection(row, false)
+			})
+			return true
+		}
+	}
+	return false
+}
+
+func (s *uiState) promptCreateVolume() {
+	s.mutex.Lock()
+	if s.createVolumePromptVisible || s.searchVisible || s.autoRefreshPromptVisible ||
+		s.confirmVisible || s.legendVisible || s.pages == nil ||
+		s.currentCluster == "" {
+		s.mutex.Unlock()
+		return
+	}
+	s.createVolumePromptVisible = true
+	s.createVolumeName = ""
+	s.createVolumeFocus = s.app.GetFocus()
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	input := tview.NewInputField().
+		SetLabel("Volume name: ").
+		SetFieldWidth(30)
+	input.SetDoneFunc(func(key tcell.Key) {
+		switch key {
+		case tcell.KeyEnter:
+			s.handleCreateVolumeName(strings.TrimSpace(input.GetText()))
+		case tcell.KeyEscape:
+			s.hideCreateVolumePrompt()
+		}
+	})
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Create Volume")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) handleCreateVolumeName(name string) {
+	if name == "" {
+		s.setStatus("[red]Volume name cannot be empty")
+		return
+	}
+
+	s.mutex.Lock()
+	s.createVolumeName = name
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	input := tview.NewInputField().
+		SetLabel("Volume size (e.g. 5Gi): ").
+		SetFieldWidth(15)
+	input.SetDoneFunc(func(key tcell.Key) {
+		switch key {
+		case tcell.KeyEnter:
+			s.handleCreateVolumeSize(name, strings.TrimSpace(input.GetText()))
+		case tcell.KeyEscape:
+			s.hideCreateVolumePrompt()
+		}
+	})
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Create Volume")
+		input.SetBorder(false)
+		container.AddItem(input, 0, 1, true)
+	})
+	s.app.SetFocus(input)
+}
+
+func (s *uiState) handleCreateVolumeSize(name, size string) {
+	if size == "" {
+		s.setStatus("[red]Volume size cannot be empty")
+		return
+	}
+
+	s.hideCreateVolumePrompt()
+	s.setStatus(fmt.Sprintf("[yellow]Creating volume %q (%s)...", name, size))
+
+	clusterName := s.currentCluster
+	clusterCfg := s.conf.Oscar[clusterName]
+	if clusterCfg == nil {
+		s.setStatus(fmt.Sprintf("[red]Cluster %q configuration not found", clusterName))
+		return
+	}
+
+	go func() {
+		_, err := volume.CreateVolume(clusterCfg, name, size)
+		if err != nil {
+			s.setStatus(fmt.Sprintf("[red]Failed to create volume %q: %v", name, err))
+			return
+		}
+		s.setStatus(fmt.Sprintf("[green]Volume %q created", name))
+		s.refreshCurrent(context.Background())
+	}()
+}
+
+func (s *uiState) hideCreateVolumePrompt() {
+	s.mutex.Lock()
+	if !s.createVolumePromptVisible {
+		s.mutex.Unlock()
+		return
+	}
+	s.createVolumePromptVisible = false
+	s.createVolumeName = ""
+	focus := s.createVolumeFocus
+	s.createVolumeFocus = nil
+	container := s.statusContainer
+	s.mutex.Unlock()
+
+	s.queueUpdate(func() {
+		container.Clear()
+		container.SetTitle("Status")
+		container.AddItem(s.statusView, 0, 1, false)
+		s.statusView.SetText(s.decorateStatusText(statusHelpText))
+	})
+	if focus != nil {
+		s.app.SetFocus(focus)
+	}
+}


### PR DESCRIPTION
## Summary

Major update to the TUI () and supporting CLI commands.

## Changes

### New CLI commands
- **Quota**: get, update
- **Metrics**: summary, breakdown, service
- **Deployment**: status, logs
- **Federation**: get, create, update, delete
- **Volume**: list, create, get, delete
- **Bucket**: list, get, create, update, delete, put-file, delete-file, presign

### TUI enhancements
- Quota get/update (5-step wizard for basic auth)
- Deployment status and logs display
- Command palette (`:`) with autocomplete, backspace dismiss
- Search (`/`) scoped to current mode (services/buckets/volumes)
- Volumes and buckets views
- Bucket objects table with pagination, upload
- Contextual help (`?`) per mode
- Backspace dismisses active prompts
- Mode-scoped search (focus on cluster list falls back to current view data)

### Internal packages
- `pkg/cluster/quotas.go` — GetQuota, UpdateQuota
- `pkg/cluster/metrics.go` — GetMetricsSummary, GetMetricsBreakdown, GetServiceMetrics
- `pkg/service/deployment.go` — GetDeploymentStatus, GetDeploymentLogs
- `pkg/service/federation.go` — GetFederation, CreateFederation, UpdateFederation, DeleteFederation
- `pkg/volume/volume.go` — ListVolumes, CreateVolume, GetVolume, DeleteVolume
- `pkg/storage/storage.go` — extended bucket operations (create, update, delete, presign, paginated listing)

## Files changed
47 files, +5249 lines